### PR TITLE
add HITL mode for SOTA suggestions (#109)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,3 +52,4 @@ model_recommender:
   enable_web_search: true  # Enable web search for finding SOTA strategies
 developer:
   hitl_instructions: []  # Human-In-The-Loop: If non-empty, these instructions are added to the developer's system prompt to guide implementation. Example: ["Use gradient clipping to prevent exploding gradients", "Implement mixed precision training", "Focus on domain-specific data augmentation"]
+  hitl_sota: false  # When true, pause after SOTA suggestion for human accept/override (forces single worker)

--- a/project_config.py
+++ b/project_config.py
@@ -56,6 +56,7 @@ _DEFAULT_CONFIG: dict[str, Any] = {
     },
     "developer": {
         "hitl_instructions": [],
+        "hitl_sota": False,
     },
 }
 


### PR DESCRIPTION
## Summary

- Add HITL mode for SOTA suggestions (`hitl_sota` config flag, closes #109): after the automated suggestion is generated, the user can accept or override it with their own suggestion and optional code snippet
- When `hitl_sota` is enabled, parallel workers are forced to 1 with a terminal warning

## Test plan

- [x] Syntax validation passes on all modified files
- [x] Config loads correctly with `hitl_sota: false` default
- [ ] Set `hitl_sota: true` — verify warning printed, single worker, prompt appears after SOTA suggestion
- [ ] Accept suggestion (Enter) — verify original suggestion flows through
- [ ] Override suggestion (type text + optional code) — verify replacement used by developer agent
- [ ] Set `hitl_sota: false` — verify no prompts, fully automated as before
