### PR TITLE
replace HITL instructions in config with INSTRUCTIONS.md (#124)

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,5 @@
+# Researcher Instructions
+
+# Developer Instructions
+
+# Models

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Before running the agent, create these files in `task/<slug>/`:
 - **`cv_splits.json`**: Cross-validation fold indices
 - **`metric.py`**: Competition-specific evaluation metric
 
-Optionally, configure Human-In-The-Loop (HITL) instructions in `config.yaml`:
-- `researcher.hitl_instructions`: Guide research direction
-- `model_recommender.hitl_models`: Override model selection
-- `developer.hitl_instructions`: Guide code implementation
+Optionally, add Human-In-The-Loop (HITL) instructions in `INSTRUCTIONS.md`:
+- `# Researcher Instructions`: Guide research direction
+- `# Models`: Override model selection
+- `# Developer Instructions`: Guide code implementation
 
 ### 5. Launch
 

--- a/agents/developer.py
+++ b/agents/developer.py
@@ -10,7 +10,7 @@ from typing import Optional
 import json
 
 from dotenv import load_dotenv
-from project_config import get_config, get_config_value
+from project_config import get_config, get_config_value, get_instructions
 import weave
 import wandb
 
@@ -57,7 +57,7 @@ _PATCH_MODE_ENABLED = bool(_RUNTIME_CFG.get("patch_mode_enabled"))
 _USE_VALIDATION_SCORE = bool(_RUNTIME_CFG.get("use_validation_score"))
 
 _DEVELOPER_MODEL = _LLM_CFG.get("developer_model")
-_HITL_INSTRUCTIONS = _DEVELOPER_CFG.get("hitl_instructions", [])
+_HITL_INSTRUCTIONS = get_instructions()["# Developer Instructions"]
 _HITL_SOTA = bool(_DEVELOPER_CFG.get("hitl_sota"))
 
 _TASK_ROOT = Path(_PATH_CFG.get("task_root"))

--- a/agents/model_recommender.py
+++ b/agents/model_recommender.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 import weave
 from weave.trace.util import ThreadPoolExecutor
 
-from project_config import get_config
+from project_config import get_config, get_instructions
 from tools.helpers import call_llm_with_retry, call_llm_with_retry_anthropic, call_llm_with_retry_google
 from tools.generate_paper_summary import PaperSummaryClient
 from utils.llm_utils import detect_provider, extract_text_from_response, append_message
@@ -45,7 +45,7 @@ _RUNTIME_CFG = _CONFIG.get("runtime")
 
 _MODEL_SELECTOR_MODEL = _LLM_CFG.get("model_selector_model")
 _MODEL_RECOMMENDER_MODEL = _LLM_CFG.get("model_recommender_model")
-_HITL_MODELS = _MODEL_REC_CFG.get("hitl_models", [])
+_HITL_MODELS = get_instructions()["# Models"]
 _ENABLE_WEB_SEARCH = _MODEL_REC_CFG.get("enable_web_search", True)
 
 _TASK_ROOT = Path(_PATH_CFG.get("task_root"))

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -10,7 +10,7 @@ from agents.researcher import ResearcherAgent
 from agents.developer import DeveloperAgent
 from agents.starter import StarterAgent
 from agents.model_recommender import ModelRecommenderAgent
-from project_config import get_config
+from project_config import get_config, get_instructions
 from weave.trace.util import ThreadPoolExecutor
 import weave
 
@@ -549,7 +549,7 @@ class Orchestrator:
             model_rec_agent = ModelRecommenderAgent(self.slug, self.iteration)
 
             # Check if human provided models (HITL mode)
-            hitl_models = _CONFIG.get("model_recommender", {}).get("hitl_models", [])
+            hitl_models = get_instructions()["# Models"]
 
             if hitl_models and len(hitl_models) > 0:
                 # HITL mode: Use human-specified models, skip LLM selection

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -5,7 +5,7 @@ import base64
 from pathlib import Path
 
 from dotenv import load_dotenv
-from project_config import get_config
+from project_config import get_config, get_instructions
 
 from tools.researcher import read_research_paper, scrape_web_page
 from tools.developer import execute_code, _build_resource_header
@@ -30,7 +30,7 @@ _TASK_ROOT = Path(_PATH_CFG.get("task_root"))
 _OUTPUTS_DIRNAME = _PATH_CFG.get("outputs_dirname")
 
 _DEFAULT_MAX_STEPS = _RUNTIME_CFG.get("researcher_max_steps")
-_HITL_INSTRUCTIONS = _RESEARCHER_CFG.get("hitl_instructions", [])
+_HITL_INSTRUCTIONS = get_instructions()["# Researcher Instructions"]
 
 # Media ingestion limits/types
 SUPPORTED_IMAGE_TYPES = {".png", ".jpg", ".jpeg", ".webp", ".gif"}

--- a/config.yaml
+++ b/config.yaml
@@ -40,11 +40,7 @@ tracking:
   wandb:
     entity: bogoconic1 # replace with your W&B entity
     project: qgentic-ai # replace with your W&B project
-researcher:
-  hitl_instructions: []  # Human-In-The-Loop: If non-empty, these instructions are added to the researcher's system prompt. Example: ["Focus on time-series cross-validation", "Analyze seasonality patterns", "Consider external weather data"]
 model_recommender:
-  hitl_models: []  # Human-In-The-Loop: If non-empty, use these models instead of LLM selection. Example: ["xgboost", "lightgbm", "deberta-v3-large"]
   enable_web_search: true  # Enable web search for finding SOTA strategies
 developer:
-  hitl_instructions: []  # Human-In-The-Loop: If non-empty, these instructions are added to the developer's system prompt to guide implementation. Example: ["Use gradient clipping to prevent exploding gradients", "Implement mixed precision training", "Focus on domain-specific data augmentation"]
   hitl_sota: false  # When true, pause after SOTA suggestion for human accept/override (forces single worker)

--- a/project_config.py
+++ b/project_config.py
@@ -42,15 +42,10 @@ _DEFAULT_CONFIG: dict[str, Any] = {
             "project": None,
         }
     },
-    "researcher": {
-        "hitl_instructions": [],
-    },
     "model_recommender": {
-        "hitl_models": [],
         "enable_web_search": True,
     },
     "developer": {
-        "hitl_instructions": [],
         "hitl_sota": False,
     },
 }
@@ -94,3 +89,46 @@ def get_config_value(*keys: str, default: Any | None = None) -> Any:
         else:
             return default
     return cfg
+
+
+_INSTRUCTIONS_HEADINGS = [
+    "# Researcher Instructions",
+    "# Developer Instructions",
+    "# Models",
+]
+
+
+def _extract_section(text: str, heading: str, next_heading: str | None) -> list[str]:
+    """Extract non-empty lines between ``heading`` and ``next_heading``."""
+    start = text.find(heading)
+    if start == -1:
+        return []
+    start += len(heading)
+    if next_heading is not None:
+        end = text.find(next_heading, start)
+        chunk = text[start:end] if end != -1 else text[start:]
+    else:
+        chunk = text[start:]
+    return [line.strip() for line in chunk.splitlines() if line.strip()]
+
+
+@lru_cache(maxsize=1)
+def get_instructions() -> dict[str, list[str]]:
+    """Parse INSTRUCTIONS.md and return content under each known H1 heading.
+
+    Headings (in order): # Researcher Instructions, # Developer Instructions, # Models.
+    Every non-empty line between one heading and the next belongs to that section.
+    """
+    instructions_path = Path(__file__).resolve().parent / "INSTRUCTIONS.md"
+    if not instructions_path.exists():
+        return {h: [] for h in _INSTRUCTIONS_HEADINGS}
+    try:
+        text = instructions_path.read_text(encoding="utf-8")
+    except Exception:
+        return {h: [] for h in _INSTRUCTIONS_HEADINGS}
+
+    sections: dict[str, list[str]] = {}
+    for i, heading in enumerate(_INSTRUCTIONS_HEADINGS):
+        next_heading = _INSTRUCTIONS_HEADINGS[i + 1] if i + 1 < len(_INSTRUCTIONS_HEADINGS) else None
+        sections[heading] = _extract_section(text, heading, next_heading)
+    return sections


### PR DESCRIPTION
## Summary
- Replace HITL instruction lists in `config.yaml` with a single `INSTRUCTIONS.md` file parsed by H1 headings (`# Researcher Instructions`, `# Developer Instructions`, `# Models`)
- Add `get_instructions()` parser in `project_config.py` that extracts non-empty lines between known headings
- Remove `researcher.hitl_instructions`, `developer.hitl_instructions`, and `model_recommender.hitl_models` from config; `developer.hitl_sota` (boolean) remains in config

## Test plan
- [x] All 41 existing tests pass
- [ ] Verify empty `INSTRUCTIONS.md` produces no instructions (same as previous default)
- [ ] Add lines under each heading and confirm they appear in agent system prompts
