### PR TITLE
remove multi-fold toggling and fold split strategy suggestions

### DIFF
--- a/agents/model_recommender.py
+++ b/agents/model_recommender.py
@@ -438,15 +438,6 @@ class ModelRecommenderAgent:
 
             logger.info("Stage 1: Selected %d candidate models", len(candidate_models))
 
-            # Save fold split strategy
-            if parsed.fold_split_strategy:
-                fold_split_path = self.outputs_dir / "fold_split_strategy.json"
-                try:
-                    with open(fold_split_path, "w") as f:
-                        json.dump({"strategy": parsed.fold_split_strategy.strategy}, f, indent=2)
-                except Exception:
-                    pass
-
             # Save candidate models
             candidate_models_path = self.outputs_dir / "candidate_models.json"
             try:

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -405,14 +405,6 @@ def _format_recommendations_for_developer(recommendations: dict) -> str:
     """
     details = []
 
-    # Fold split strategy
-    fold_split = recommendations.get("fold_split_strategy", {})
-    if fold_split:
-        strategy = fold_split.get("strategy", "")
-        if strategy:
-            details.append("## Cross-Validation Strategy")
-            details.append(f"- Use {strategy}")
-
     # Preprocessing
     preprocessing = recommendations.get("preprocessing", {})
     if preprocessing:
@@ -566,25 +558,12 @@ class Orchestrator:
             else:
                 raise RuntimeError("No model recommendations found")
 
-        # Load fold split strategy (single strategy for all models)
-        fold_split_strategy_path = self.outputs_dir / "fold_split_strategy.json"
-        fold_split_strategy = {}
-        if fold_split_strategy_path.exists():
-            try:
-                with open(fold_split_strategy_path, "r") as f:
-                    fold_split_strategy = json.load(f)
-            except Exception:
-                pass
-
         # Extract NOW and LATER recommendations for each model
         now_recommendations_all = {}
         later_recommendations_all = {}
 
         for model_name, recommendations in model_recommendations.items():
             now_recs = _extract_now_recommendations(recommendations)
-            # Add the fold split strategy to each model's recommendations
-            if fold_split_strategy:
-                now_recs["fold_split_strategy"] = fold_split_strategy
             now_recommendations_all[model_name] = now_recs
             later_recommendations_all[model_name] = _extract_later_recommendations(recommendations)
         
@@ -726,7 +705,6 @@ class Orchestrator:
                                 "best_code_file": best_code_file or "",
                                 "blacklisted_ideas": blacklisted_ideas,
                                 "successful_ideas": successful_ideas,
-                                "fold_split_strategy": fold_split_strategy,
                                 "now_recommendations": now_recommendations_all.get(result_key, {}),
                                 "later_recommendations": later_recommendations_all.get(result_key, {})
                             }

--- a/prompts/developer_agent.py
+++ b/prompts/developer_agent.py
@@ -83,27 +83,20 @@ File contents:
     return ""
 
 
-def _get_hard_constraints(model_name: str, allow_multi_fold: bool = False) -> str:
+def _get_hard_constraints(model_name: str) -> str:
     """
     Get the hard constraints section for developer agent system prompts.
 
-    This is a wrapper around the shared get_hard_constraints function that
-    maintains backward compatibility with the existing developer agent interface.
-
     Args:
         model_name: The model name to be used in constraints
-        allow_multi_fold: Whether to allow multi-fold training
 
     Returns:
         Formatted hard constraints string
     """
-    return get_hard_constraints(
-        model_name=model_name,
-        allow_multi_fold=allow_multi_fold,
-    )
+    return get_hard_constraints(model_name=model_name)
 
 
-def build_system(description: str, directory_listing: str, model_name: str, slug: str, cpu_core_range: list[int] | None = None, gpu_identifier: str | None = None, gpu_isolation_mode: str = "none", allow_multi_fold: bool = False, hitl_instructions: list[str] | None = None) -> str:
+def build_system(description: str, directory_listing: str, model_name: str, slug: str, cpu_core_range: list[int] | None = None, gpu_identifier: str | None = None, gpu_isolation_mode: str = "none", hitl_instructions: list[str] | None = None) -> str:
     # Build resource allocation info
     resource_info = ""
     if cpu_core_range is not None:
@@ -125,7 +118,7 @@ You have been provided with the following guidance for code implementation:
 ---
 """
 
-    constraints = _get_hard_constraints(model_name, allow_multi_fold=allow_multi_fold)
+    constraints = _get_hard_constraints(model_name)
 
     # Read helper files (cv_splits.json, metric.py) if they exist
     helper_files_section = _read_helper_files(slug)

--- a/prompts/guardrails.py
+++ b/prompts/guardrails.py
@@ -12,8 +12,6 @@ Begin with a concise checklist (3-7 bullets) of what you will do; keep items con
   - Using any test labels or generating features derived from test labels in any part of the pipeline.
   - Performing feature selection or target encoding outside of cross-validation (CV) or out-of-fold (OOF) contexts.
   - Introducing data leaks via merges or aggregations that incorporate information from the test set or from the future.
-  - Employing an incorrect data splitting strategy (e.g., random splits used with time series, which is inappropriate).
-  - Using KFold instead of StratifiedKFold for classification tasks when labels are imbalanced.
 - For each issue found, point to the relevant code snippet or describe the problematic portion. Provide a succinct rationale for why it is risky, along with a suggested fix.
 
 **NOTE:** Loading external fails SHOULD NOT be flagged as leakage!

--- a/prompts/model_recommender_agent.py
+++ b/prompts/model_recommender_agent.py
@@ -34,8 +34,7 @@ Begin with a **concise checklist (3-7 conceptual bullets)** describing your reas
 
 ## Objective
 1. Review all inputs to understand **data characteristics, task type, and evaluation metric**.
-2. **Determine the single best fold splitting strategy** based on data characteristics in <research_plan>. Be SPECIFIC and include as many details as possible.
-3. **IMPORTANT: When performing web searches, add "2025" to your queries to find the most recent models and techniques.**
+2. **IMPORTANT: When performing web searches, add "2025" to your queries to find the most recent models and techniques.**
 4. Perform **targeted web searches** to identify **state-of-the-art models** relevant to the task, data, and metric.
 5. You MUST web search for 2025 released models which showcase strong performance on similar <task_type> tasks and datasets.
 6. **IMPORTANT**: The models should be diverse in architecture and approach, so that they can ensemble well later.
@@ -57,10 +56,7 @@ Begin with a **concise checklist (3-7 conceptual bullets)** describing your reas
 ## Output Format
 
 ### Checklist (3-7 bullets)
-High-level steps you will follow (conceptual only). MUST include determining the fold splitting strategy as one step.
-
-### Fold Split Strategy Analysis
-Analyze data characteristics and <research_plan> and explain why your chosen fold split is the best fit.
+High-level steps you will follow (conceptual only).
 
 ### Considered Models
 List up to **16 candidate models** briefly explaining why each was considered.
@@ -76,12 +72,7 @@ Model 2
 ...
 
 ### Final Recommendations
-Provide recommendations with **fold_split_strategy** and **recommended_models**.
-The **fold_split_strategy** must be a single, specific strategy.
-
-**fold_split_strategy**: An object with a "strategy" field containing the single specific CV fold splitting strategy
-
-**recommended_models**: A list of model recommendations, each with:
+Provide **recommended_models** as a list of model recommendations, each with:
 - "name": The model name
 - "reason": Why this model is recommended for this competition/data/metric
 """
@@ -134,7 +125,6 @@ Begin with a concise checklist (3-7 bullets) describing your *process* (conceptu
 - ❌ Do **not** search for or use actual winning solutions from this specific competition.
 - ❌ Do **not** mark untested strategies as MUST_HAVE (even if they're good ideas)
 - ❌ Do **not** ignore validated features from plan.md—they MUST appear in MUST_HAVE with explicit reference
-- ❌ Do **not** discuss CV/fold splitting strategies - this is handled elsewhere.
 - ❌ Anything under ensembling/stacking/calibration/blending MUST be in NICE_TO_HAVE.
 - ✅ Always reference plan.md when using validated findings: cite the strategy name and AUC impact
 
@@ -236,7 +226,6 @@ Begin with a **concise checklist (3-7 bullets)** summarizing your conceptual rea
 ## Hard Constraints
 - Do **not** search for or use actual winning solutions from this specific competition.
 - Do **not** rely on prior competition knowledge.
-- Do **not** discuss or recommend CV/fold splitting strategies - this is handled elsewhere.
 - Recommend exactly **one** primary loss for MUST_HAVE.
 - NICE_TO_HAVE may contain **multiple losses** (ensembled, multi-task, or joint).
 - Do **not** specify hyperparameters, architecture, or preprocessing choices here.
@@ -343,7 +332,6 @@ Begin with a **concise checklist (3-7 conceptual bullets)** describing your reas
 - ❌ Do **not** search for or use actual winning solutions from this specific competition.
 - ❌ Do **not** provide ranges in MUST_HAVE (ranges go in NICE_TO_HAVE)
 - ❌ Do **not** leave hyperparameters unspecified - baseline values are required
-- ❌ Do **not** discuss CV/fold splitting strategies - this is handled elsewhere.
 - ❌ Do not redefine loss functions or preprocessing steps — they exist elsewhere.
 - ✅ MUST_HAVE parameters must be sufficient to train the model without guessing
 - ✅ All recommendations must fit the {time_limit_minutes}-minute training budget.
@@ -443,7 +431,6 @@ All strategies must be **realistically executable** within these constraints.
 ## Hard Constraints
 - Do **not** search for or use actual winning solutions from this specific competition.
 - Do **not** rely on prior knowledge of the competition.
-- Do **not** discuss or recommend CV/fold splitting strategies - this is handled elsewhere.
 - Do **not** include training-time augmentations or losses.
 - Focus **strictly on inference-time logic** (prediction, calibration, or post-processing).
 - Anything under ensembling/stacking/calibration/blending MUST be in the NICE_TO_HAVE section.
@@ -468,7 +455,7 @@ When selecting inference strategies:
 1. **Metric alignment first** - Does it directly optimize leaderboard metric?
 2. **Runtime realism** - ≤ {inference_time_limit_minutes} minutes total inference time.
 3. **Implementation simplicity** - Prefer single-line or vectorized modifications.
-4. **Scalability** - Can extend to ensemble or multi-fold setups later.
+4. **Scalability** - Can extend to ensemble setups later.
 
 ---
 

--- a/prompts/researcher_agent.py
+++ b/prompts/researcher_agent.py
@@ -276,14 +276,13 @@ Hypothesis 2: Customer segments behave differently (business knowledge)
 Hypothesis 3: Seasonality affects churn (retail domain)
 → Test: Churn rate by month/quarter
 → Finding: +40% churn after holiday season (Jan-Feb)
-→ Recommendation: Seasonal features (cyclical encoding), time-aware validation
+→ Recommendation: Seasonal features (cyclical encoding)
 
 Plan:
 - RFM feature engineering (Recency, Frequency, Monetary value)
 - Customer lifetime value (CLV) calculation (business metric)
 - Segment identification and encoding (business-driven clustering)
 - Seasonal feature engineering (retail calendar-aware)
-- Validation strategy: Time-based split (avoid lookahead bias)
 ```
 **Why Good:** Business and e-commerce domain expertise. RFM framework from literature.
 
@@ -882,16 +881,13 @@ Respond in Markdown using this structure. For any section that cannot be complet
 # Technical Plan
 
 ## Data Strategy
-[Domain-guided data handling/preprocessing/validation. If not feasible, explain why.]
+[Domain-guided data handling/preprocessing. If not feasible, explain why.]
 
 ## Model Architecture Considerations
 [Domain-guided selection criteria—avoid naming specific models. Note if not addressed with reason.]
 
 ## Feature Engineering / Preprocessing Priorities
 [Ranked, domain-driven recommendations. State if undetermined.]
-
-## Evaluation Strategy
-[Specify domain-appropriate metrics/validation. Explain if unavailable, noting information sources.]
 
 ---
 

--- a/prompts/shared_constraints.py
+++ b/prompts/shared_constraints.py
@@ -9,15 +9,12 @@ from __future__ import annotations
 
 def get_hard_constraints(
     model_name: str | None = None,
-    allow_multi_fold: bool = False,
 ) -> str:
     """
     Get the hard constraints section for system prompts.
 
     Args:
         model_name: The model name to be used in constraints.
-        allow_multi_fold: Whether to allow multi-fold training. If False, adds a
-            constraint to only train on fold 0.
 
     Returns:
         Formatted hard constraints string ready for inclusion in system prompts.
@@ -28,11 +25,6 @@ def get_hard_constraints(
         model_constraint_lines.append(
             f"- Use ONLY `{model_name}` (no substitutions or fallback models)."
         )
-
-    # Build fold constraint (only for developer with model_name)
-    fold_constraint = ""
-    if model_name and not allow_multi_fold:
-        fold_constraint = "- Just train and validate on fold 0. Skip other folds to save time. If suggested later, you can switch to multi-fold."
 
     # Build model substitution constraint (developer-specific)
     modular_pipeline_constraint = ""
@@ -68,10 +60,6 @@ def get_hard_constraints(
     # Add common constraints
     constraints_parts.append(common_constraints)
     constraints_parts.append(additional_common_constraints)
-
-    # Add fold constraint (if applicable)
-    if fold_constraint:
-        constraints_parts.append(fold_constraint)
 
     # Add modular pipeline constraint (if applicable)
     if modular_pipeline_constraint:

--- a/prompts/tools_developer.py
+++ b/prompts/tools_developer.py
@@ -279,18 +279,17 @@ Begin with a brief, high-level statement explaining your rationale for the chose
 
 ## Suggestion Categories (Select 3 most relevant):
 1. **Data/Feature Engineering/Preprocessing**
-2. **Validation Enhancement**
-3. **Architectural Enhancement**
-4. **Hyperparameter Enhancement**
-5. **Removing Unstable/Detrimental Components**
+2. **Architectural Enhancement**
+3. **Hyperparameter Enhancement**
+4. **Removing Unstable/Detrimental Components**
 
 **Priority by Task:**
-- **Tabular/Time Series:** #1 (Feature), #5 (Remove), then #4 (Hyperparam); only do #2 (Validation) for severe issues
-- **CV/NLP/Audio:** #1 (Data), #3 (Arch.), #4 (Hyperparam); #2 (Validation) is low priority
-- **Bugs/Detrimental Items:** Always include #5
-- **Far from target:** Focus on #1/#3, avoid micro-optimizing
-- **Close to target:** Include #4
-- **At/above target:** #4 and minor #1; avoid risky arch. changes
+- **Tabular/Time Series:** #1 (Feature), #4 (Remove), then #3 (Hyperparam)
+- **CV/NLP/Audio:** #1 (Data), #2 (Arch.), #3 (Hyperparam)
+- **Bugs/Detrimental Items:** Always include #4
+- **Far from target:** Focus on #1/#2, avoid micro-optimizing
+- **Close to target:** Include #3
+- **At/above target:** #3 and minor #1; avoid risky arch. changes
 
 Make exactly THREE suggestions from different categories (numbered, clear headers). Each:
 - Has one high-impact, complementary, non-overlapping suggestion (~100 words benefit)

--- a/schemas/model_recommender.py
+++ b/schemas/model_recommender.py
@@ -5,11 +5,6 @@ from pydantic import BaseModel
 
 # Model Selection Schemas
 
-class FoldSplitStrategy(BaseModel):
-    """Fold split strategy recommendation."""
-    strategy: str
-
-
 class RecommendedModel(BaseModel):
     """Individual model recommendation."""
     name: str
@@ -18,7 +13,6 @@ class RecommendedModel(BaseModel):
 
 class ModelSelection(BaseModel):
     """Schema for model selection response."""
-    fold_split_strategy: FoldSplitStrategy
     recommended_models: list[RecommendedModel]
 
 

--- a/tests/test_model_recommender.py
+++ b/tests/test_model_recommender.py
@@ -99,7 +99,6 @@ def patch_llm_calls(monkeypatch):
                 # For model selection, return empty to trigger default behavior
                 return text_format(
                     recommended_models=[],
-                    fold_split_strategy=None
                 )
             else:
                 # Generic fallback

--- a/tests/test_shared_constraints.py
+++ b/tests/test_shared_constraints.py
@@ -1,5 +1,5 @@
 """
-Tests for shared_constraints module to ensure backward compatibility.
+Tests for shared_constraints module.
 """
 
 from __future__ import annotations
@@ -15,14 +15,11 @@ class TestSharedConstraints:
 
     def test_developer_constraints_basic(self):
         """Test that developer constraints are generated correctly with basic params."""
-        result = developer_get_hard_constraints(model_name="ResNet50", allow_multi_fold=False)
+        result = developer_get_hard_constraints(model_name="ResNet50")
 
         # Check for model-specific constraints
         assert "Use ONLY `ResNet50`" in result
         assert "do not swap out `ResNet50`" in result
-
-        # Check for fold constraint (should be present when allow_multi_fold=False)
-        assert "Just train and validate on fold 0" in result
 
         # Check for common constraints
         assert "Deliver a fully-contained, single-file script" in result
@@ -34,25 +31,10 @@ class TestSharedConstraints:
         # Check for developer-specific constraint ending (backward compatibility)
         assert "while` loops" in result
 
-    def test_developer_constraints_multi_fold(self):
-        """Test that developer constraints respect allow_multi_fold parameter."""
-        result = developer_get_hard_constraints(model_name="BERT", allow_multi_fold=True)
-
-        # Fold constraint should NOT be present when allow_multi_fold=True
-        assert "Just train and validate on fold 0" not in result
-
-        # Model-specific constraints should still be present
-        assert "Use ONLY `BERT`" in result
-
     def test_shared_function_with_all_parameters(self):
         """Test the shared function directly with all parameter combinations."""
-        # Test developer-like configuration
-        dev_result = get_hard_constraints(
-            model_name="XGBoost",
-            allow_multi_fold=False,
-        )
+        dev_result = get_hard_constraints(model_name="XGBoost")
         assert "Use ONLY `XGBoost`" in dev_result
-        assert "Just train and validate on fold 0" in dev_result
 
     def test_common_constraints_present(self):
         """Test that common constraints appear in developer output."""
@@ -80,12 +62,11 @@ class TestSharedConstraints:
             assert item in dev_result, f"Missing in developer: {item}"
 
     def test_backward_compatibility_developer(self):
-        """Test that the developer wrapper maintains exact backward compatibility."""
-        result = developer_get_hard_constraints("TestModel", allow_multi_fold=False)
+        """Test that the developer wrapper produces expected output."""
+        result = developer_get_hard_constraints("TestModel")
 
         assert result.startswith("**Hard Constraints:**")
         assert "Use ONLY `TestModel`" in result
-        assert "Just train and validate on fold 0" in result
         assert "while` loops" in result
         assert "Modular pipeline" in result
 


### PR DESCRIPTION
## Summary
- Removed multi-fold toggling logic (`allow_multi_fold` parameter, attempt 2 system prompt rebuild) from developer agent, shared constraints, and prompt threading
- Deleted `FoldSplitStrategy` schema and removed `fold_split_strategy` from `ModelSelection`, model recommender saving, orchestrator loading/injection, and baseline results
- Removed all "Do not discuss CV/fold splitting strategies" instructions from model recommender prompts (preprocessing, loss function, hyperparameter, inference strategy)
- Removed splitting strategy guardrail lines (incorrect data splitting, KFold vs StratifiedKFold) from `prompts/guardrails.py` — moot since CV splits come from `cv_splits.json`
- Removed "Validation Enhancement" suggestion category from SOTA prompts and renumbered remaining categories
- Removed "Evaluation Strategy" template section and validation strategy examples from researcher prompts
- Added early `FileNotFoundError` validation in `DeveloperAgent.__init__` for `cv_splits.json` and `metric.py`

## Test plan
- [x] All 38 tests pass
- [x] Zero remaining references to `allow_multi_fold`, `fold_split`, `FoldSplitStrategy`, `multi-fold` (verified via grep)
- [x] `_USE_VALIDATION_SCORE` only remains for validation score reading (line 906), not multi-fold toggling
