### PR TITLE
add --rollback-to-version CLI flag (#114)

### DIFF
--- a/launch_agent.py
+++ b/launch_agent.py
@@ -72,12 +72,18 @@ def main():
         type=str,
         help="Optional wandb run name override (defaults to '<iteration>-<slug>')",
     )
+    parser.add_argument(
+        "--rollback-to-version",
+        type=int,
+        default=None,
+        help="Rollback to a specific version: moves later version folders to _trash/ and deletes their checkpoints",
+    )
     args = parser.parse_args()
 
     os.environ["TASK_SLUG"] = args.slug
     _init_tracking(args)
 
-    orchestrator = Orchestrator(args.slug, args.iteration)
+    orchestrator = Orchestrator(args.slug, args.iteration, rollback_to_version=args.rollback_to_version)
     orchestrator.run()
 
     # Gracefully close tracking backends to avoid hanging background threads


### PR DESCRIPTION
## Summary
- Added `--rollback-to-version N` CLI flag to `launch_agent.py`
- Added `_rollback()` method to `Orchestrator`: moves version folders beyond N into `_trash/<timestamp>/`, deletes checkpoint rows beyond N, and removes `baseline_results.json` so models get re-queued
- After rollback, the developer's existing resume logic picks up version N's checkpoint automatically

## Test plan
- [ ] Test rollback: `--rollback-to-version 3` — verify folders 4+ moved to `_trash/<timestamp>/`, checkpoint rows 4+ deleted, agent resumes from v3
- [ ] Test rollback with invalid version — verify early `ValueError`
- [ ] Test multiple rollbacks — verify each creates a separate timestamped `_trash/` subfolder
