### PR TITLE
move is_lower_better and gold_threshold to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,8 @@ runtime:
   baseline_code_timeout: 43200  # 12 hours for baseline code execution
   # Grading strategy
   use_validation_score: true  # If true, use validation score from logs instead of MLE-bench grading (faster, no ground truth needed)
+  is_lower_better: false  # Metric direction: true if lower scores are better (e.g. MSE), false if higher is better (e.g. R²)
+  gold_threshold: null  # Target score to reach (null = no target)
 paths:
   task_root: "task"
   outputs_dirname: "outputs"


### PR DESCRIPTION
## Summary
- Moved `is_lower_better` and `gold_threshold` from mlebench grading into `config.yaml` under `runtime:`
- Removed `_load_benchmark_info()` method from `DeveloperAgent` — no longer calls `mlebench grade-sample` at init
- Added test competition `task/test-checkpoint/` with pre-populated phase 1-3 outputs for quick checkpoint/resume/rollback testing
- Switched all LLM models to `gemini-3-flash-preview` for testing
- Added HITL instructions to `INSTRUCTIONS.md` for all three sections

## Test plan
- [ ] Run `python launch_agent.py --slug test-checkpoint --iteration 99` — verify developer loop starts without mlebench errors
- [ ] Verify `is_lower_better=false` and `gold_threshold=null` are read from config correctly
- [ ] Kill and re-run to test checkpoint resume
- [ ] Test rollback with `--rollback-to-version N`
