### PR TITLE
restore shared suggestions on checkpoint resume

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -1186,6 +1186,12 @@ class DeveloperAgent:
             if train_path.exists():
                 self.best_code = strip_header_from_code(train_path)
 
+        # Re-populate class-level shared suggestions from this model's history
+        with DeveloperAgent._lock:
+            for entry in self.global_suggestions:
+                if entry not in DeveloperAgent._shared_suggestions:
+                    DeveloperAgent._shared_suggestions.append(entry)
+
         return {
             "input_list": row["input_list"],
             "last_input_tokens": row["last_input_tokens"],


### PR DESCRIPTION
## Summary
- Fixed `_shared_suggestions` being empty after checkpoint resume by re-populating the class-level list from the restored `global_suggestions`

## Test plan
- [ ] Run agent, kill mid-run, resume — verify "Using N shared suggestions" shows the correct count (not 0)
