### PR TITLE
fix Gemini function call response handling in search_sota_suggestions

### DIFF
--- a/tools/developer.py
+++ b/tools/developer.py
@@ -663,8 +663,8 @@ def search_sota_suggestions(
                         )
                     )
 
-            # Add assistant message and function results
-            input_list.append(append_message(provider, "assistant", response.text if hasattr(response, 'text') else ""))
+            # Add model's full response (preserves function_call parts)
+            input_list.append(response.candidates[0].content)
             if function_responses:
                 input_list.append(types.Content(role="function", parts=function_responses))
 


### PR DESCRIPTION
## Summary
- Fix `search_sota_suggestions` in `tools/developer.py` to preserve Gemini function call responses using `response.candidates[0].content` instead of `response.text` (which is `None` for function call responses), preventing 400 INVALID_ARGUMENT errors on subsequent multi-turn calls

## Test plan
- [x] Demo script `demos/demo_gemini_function_calling.py` validates that `response.text` is `None` for function calls and `response.candidates[0].content` preserves the full response
- [x] Full agent loop with `--rollback-to-version 3` confirms `search_sota_suggestions` handles function calls through 20 steps without 400 errors
