### PR TITLE
add per-step HITL to SOTA suggestions tool loop (#119)

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -1090,6 +1090,7 @@ class DeveloperAgent:
                 version=version,
                 images=training_images if training_images else None,
                 train_stats=train_stats,
+                hitl_sota=_HITL_SOTA,
             )
 
             # HITL: Show suggestion and let user accept or override

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,4 +65,3 @@ torchgeo
 scikit-image
 
 google-genai
-google-api-core

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -5,7 +5,6 @@ import time
 import anthropic
 from anthropic import Anthropic
 from google import genai
-from google.api_core import exceptions as google_exceptions
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 import httpx
@@ -36,11 +35,6 @@ RETRYABLE_EXCEPTIONS = (
     anthropic.APITimeoutError,
     anthropic.RateLimitError,
     anthropic.InternalServerError,
-    google_exceptions.ServiceUnavailable,
-    google_exceptions.DeadlineExceeded,
-    google_exceptions.ResourceExhausted,
-    google_exceptions.Aborted,
-    google_exceptions.InternalServerError,
     genai_errors.ServerError,
     genai_errors.ClientError,
 )


### PR DESCRIPTION
## Summary
- Add per-step HITL to SOTA suggestions tool loop — when `hitl_sota=true`, the user is prompted after each tool step to provide guidance or type `done` to finish
- User guidance is injected into the LLM conversation with provider-specific formatting (handles Anthropic's alternating-role constraint)
- No max tool step limit when HITL is active — the human controls when to stop
- Remove unused `google-api-core` dependency (not used by `google-genai` SDK)

## Test plan
- [ ] Set `hitl_sota: true` in config, run agent — verify prompt appears after each tool step
- [ ] Type guidance — verify LLM responds to it in the next step
- [ ] Type `done` — verify final structured output is generated
- [ ] Set `hitl_sota: false` — verify fully autonomous (no prompts)
- [x] `python -m pytest tests/test_developer_tools.py -v` — 16 tests pass
- [x] `python demos/test_hitl_message_injection.py` — all injection formats validated
