### PR TITLE
fix HITL stdin and silence noisy HTTP loggers (#119)

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -761,18 +761,14 @@ class Orchestrator:
             # Start with existing results (for incremental updates)
             baseline_results = existing_baseline_results.copy()
 
-            # Run developer agents in parallel using ThreadPoolExecutor
+            # Run developer agents — directly on main thread for HITL (stdin required),
+            # otherwise in parallel using ThreadPoolExecutor
             if tasks:
-                print(f"Running {len(tasks)} baseline task(s) in parallel")
-                with ThreadPoolExecutor(max_workers=max_parallel_workers) as executor:
-                    futures = [
-                        executor.submit(_run_developer_baseline, *task_args)
-                        for task_args in tasks
-                    ]
-
-                    for future in futures:
+                if _HITL_SOTA:
+                    print(f"Running {len(tasks)} baseline task(s) sequentially (HITL mode)")
+                    for task_args in tasks:
                         try:
-                            result_key, best_score, best_code_file, blacklisted_ideas, successful_ideas = future.result()
+                            result_key, best_score, best_code_file, blacklisted_ideas, successful_ideas = _run_developer_baseline(*task_args)
                             baseline_results[result_key] = {
                                 "model_name": result_key,
                                 "best_score": best_score,
@@ -782,13 +778,38 @@ class Orchestrator:
                                 "now_recommendations": now_recommendations_all.get(result_key, {}),
                                 "later_recommendations": later_recommendations_all.get(result_key, {})
                             }
-                            # Incrementally persist after each completion
                             baseline_path = self.outputs_dir / "baseline_results.json"
                             with open(baseline_path, "w") as f:
                                 json.dump(baseline_results, f, indent=2)
                         except Exception as e:
                             print(f"Error in baseline task: {e}")
                             continue
+                else:
+                    print(f"Running {len(tasks)} baseline task(s) in parallel")
+                    with ThreadPoolExecutor(max_workers=max_parallel_workers) as executor:
+                        futures = [
+                            executor.submit(_run_developer_baseline, *task_args)
+                            for task_args in tasks
+                        ]
+
+                        for future in futures:
+                            try:
+                                result_key, best_score, best_code_file, blacklisted_ideas, successful_ideas = future.result()
+                                baseline_results[result_key] = {
+                                    "model_name": result_key,
+                                    "best_score": best_score,
+                                    "best_code_file": best_code_file or "",
+                                    "blacklisted_ideas": blacklisted_ideas,
+                                    "successful_ideas": successful_ideas,
+                                    "now_recommendations": now_recommendations_all.get(result_key, {}),
+                                    "later_recommendations": later_recommendations_all.get(result_key, {})
+                                }
+                                baseline_path = self.outputs_dir / "baseline_results.json"
+                                with open(baseline_path, "w") as f:
+                                    json.dump(baseline_results, f, indent=2)
+                            except Exception as e:
+                                print(f"Error in baseline task: {e}")
+                                continue
             else:
                 print("No new baseline tasks to run (all models already completed)")
 

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -85,6 +85,8 @@ class ResearcherAgent:
             logging.basicConfig(
                 level=logging.DEBUG,
             )
+            for _noisy in ("httpcore", "httpx", "urllib3"):
+                logging.getLogger(_noisy).setLevel(logging.WARNING)
 
         # Prevent duplicate handlers
         existing_paths = {

--- a/config.yaml
+++ b/config.yaml
@@ -45,4 +45,4 @@ tracking:
 model_recommender:
   enable_web_search: true  # Enable web search for finding SOTA strategies
 developer:
-  hitl_sota: false  # When true, pause after SOTA suggestion for human accept/override (forces single worker)
+  hitl_sota: true  # When true, pause after SOTA suggestion for human accept/override (forces single worker)

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -33,6 +33,8 @@ logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
 )
+for _noisy in ("httpcore", "httpx", "urllib3"):
+    logging.getLogger(_noisy).setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 

--- a/tools/researcher.py
+++ b/tools/researcher.py
@@ -14,6 +14,8 @@ logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
 )
+for _noisy in ("httpcore", "httpx", "urllib3"):
+    logging.getLogger(_noisy).setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- Run developer agents on main thread in HITL mode so `input()` can read stdin (ThreadPoolExecutor threads cause EOFError)
- Silence noisy `httpcore`/`httpx`/`urllib3` DEBUG loggers so HITL prompts are readable

## Test plan
- [x] Set `hitl_sota: true` in config, run agent — HITL prompt appears and accepts input without EOFError
- [x] Type guidance ("can you try xgboost?") — LLM responds with XGBoost suggestion in next step
- [x] Console output is clean — no HTTP DEBUG noise drowning the prompt
