### PR TITLE
non-blocking execute_code with LLM log monitoring (#137) (#142)

### DIFF
--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -311,7 +311,8 @@ class ResearcherAgent:
                 script_file.write_text(resource_header + code)
 
                 logger.info("execute_python (code_len=%d, step=%d)", len(code), step)
-                tool_output = execute_code(str(script_file), timeout_seconds=300)
+                job = execute_code(str(script_file), timeout_seconds=300)
+                tool_output = job.result()
 
                 result = self._format_tool_result(tool_id, {"output": tool_output}, provider)
 

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,7 @@ runtime:
   # Time limits (in seconds)
   baseline_time_limit: 432000  # 5 days for baseline development
   baseline_code_timeout: 43200  # 12 hours for baseline code execution
+  log_monitor_interval: 120  # Seconds between LLM log monitor calls during code execution
   # Grading strategy
   use_validation_score: true  # If true, use validation score from logs instead of MLE-bench grading (faster, no ground truth needed)
   is_lower_better: false  # Metric direction: true if lower scores are better (e.g. MSE), false if higher is better (e.g. R²)

--- a/prompts/tools_developer.py
+++ b/prompts/tools_developer.py
@@ -360,3 +360,57 @@ def sota_user(
 
 {context}
 """
+
+
+def log_monitor_system() -> str:
+    return """You are a training run health monitor. You will receive recent stdout/stderr output from a running ML training script, along with timing metadata.
+
+Your job: decide whether the training process is healthy or should be killed.
+
+## When to return "kill"
+
+Return "kill" when there is clear evidence of a fatal, unrecoverable problem:
+- **NaN or Inf** in loss values (training has diverged and cannot recover)
+- **Loss explosion** (loss increasing rapidly over multiple epochs)
+- **Infinite loop** (identical output lines repeating indefinitely)
+- **Deadlock** (no output for extended time + process not using CPU/GPU — use execute_bash to check)
+- **CUDA errors** that will not resolve (e.g., device-side assert, illegal memory access)
+- **Out of memory warnings** that precede an inevitable OOM crash
+
+## When to return "continue"
+
+Return "continue" when training looks healthy OR the evidence is ambiguous:
+- Loss is decreasing or fluctuating normally
+- Process is producing output at a reasonable rate
+- Silence is expected (data loading, model compilation, evaluation phase)
+- Slow but steady progress
+
+## Using execute_bash
+
+When log output alone is insufficient, use the execute_bash tool to diagnose:
+- `nvidia-smi` — check GPU utilization and memory (0% GPU + silence = likely deadlock)
+- `ps -p <pid> -o %cpu,%mem,etime` — check if process is consuming CPU
+- `free -m` — check available system memory
+
+Only use tools when the logs are ambiguous. If the logs clearly show NaN loss or healthy training, return your verdict immediately without tool use.
+
+## Response format
+
+You MUST return a JSON object with exactly two fields:
+- "action": either "continue" or "kill"
+- "reason": a concise explanation (1-2 sentences)"""
+
+
+def log_monitor_user(
+    log_output: str,
+    seconds_since_last_output: float,
+    total_elapsed_seconds: float,
+    pid: int,
+) -> str:
+    return f"""<logs>
+{log_output}
+</logs>
+
+seconds_since_last_output: {seconds_since_last_output:.0f}
+total_elapsed_seconds: {total_elapsed_seconds:.0f}
+pid: {pid}"""

--- a/schemas/developer.py
+++ b/schemas/developer.py
@@ -19,6 +19,12 @@ class SOTAResponse(BaseModel):
     suggestion_code: str
 
 
+class LogMonitorVerdict(BaseModel):
+    """LLM verdict on whether a running training script is healthy."""
+    action: str   # "continue" or "kill"
+    reason: str   # explanation — fed back to the developer agent if killed
+
+
 class CodeGeneration(BaseModel):
     """Schema for generating training code in folder structure.
 

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -423,3 +423,79 @@ def get_tools_for_provider(provider: str):
         return get_tools_gemini()
     else:
         raise ValueError(f"Unsupported provider: {provider}")
+
+
+# ---------------------------------------------------------------------------
+# Monitor tools (execute_bash for system diagnostics during training)
+# ---------------------------------------------------------------------------
+
+def get_monitor_tools_openai():
+    return [
+        {
+            "type": "function",
+            "name": "execute_bash",
+            "description": "Execute a bash command for system diagnostics. Use for checking GPU utilization (nvidia-smi), process status (ps, top), memory (free), disk (df), etc.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string", "description": "Bash command to execute."}
+                },
+            },
+            "additionalProperties": False,
+            "required": ["command"],
+        }
+    ]
+
+
+def get_monitor_tools_anthropic():
+    return [
+        {
+            "name": "execute_bash",
+            "description": """Execute a bash command for system diagnostics. Use for checking GPU utilization
+            (nvidia-smi), process status (ps, top), memory usage (free), disk space (df), and other
+            read-only system inspection commands. Do not use for modifying system state.""",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Bash command to execute."
+                    }
+                },
+                "required": ["command"]
+            }
+        }
+    ]
+
+
+def get_monitor_tools_gemini():
+    from google.genai import types
+
+    return [
+        types.FunctionDeclaration(
+            name="execute_bash",
+            description="Execute a bash command for system diagnostics. Use for checking GPU utilization (nvidia-smi), process status (ps, top), memory (free), disk (df), etc.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Bash command to execute."
+                    }
+                },
+                "required": ["command"]
+            }
+        )
+    ]
+
+
+def get_monitor_tools_for_provider(provider: str):
+    """Get monitor tools (execute_bash) in the appropriate format for the provider."""
+    if provider == "openai":
+        return get_monitor_tools_openai()
+    elif provider == "anthropic":
+        return get_monitor_tools_anthropic()
+    elif provider == "google":
+        return get_monitor_tools_gemini()
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")


### PR DESCRIPTION
## Summary
- Make `execute_code()` non-blocking by returning an `ExecutionJob` handle (via `subprocess.Popen()`) instead of blocking with `subprocess.run()`
- Add `monitor_logs()` — an LLM tool-calling function that inspects training logs and system state (via `execute_bash` tool) to decide whether to kill or continue a running process
- Developer agent now runs a monitor loop: launch job, poll `monitor_logs()` every 120s, kill on fatal issues (NaN loss, deadlock, OOM), sleep between checks
- SOTA and researcher callers stay effectively blocking via `job.result()` (short scripts don't need monitoring)
- Process cleanup uses `os.killpg(SIGKILL)` on the entire process group (DataLoader workers, multiprocessing children)

## Test plan
- [x] `python demos/test_monitored_execution.py` — 9 tests validating ExecutionJob lifecycle, streaming output, idle tracking, process group kill, timeout detection
- [x] `python demos/test_killpg_from_threadpool.py` — 5 tests confirming killpg works from ThreadPoolExecutor workers
- [x] `pytest tests/test_developer_tools.py -v` — 25 tests pass (16 existing + 9 new monitoring tests)
