### PR TITLE
remove OpenAI/Anthropic branching code (#147)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ runtime:
   researcher_max_steps: 512
   llm_max_retries: 5
   llm_backoff_sequence: [1, 5, 10, 30, 60]
-  max_developer_input_tokens: 250000  # Max input tokens before adaptive trimming (GPT-5 limit is 272K)
+  max_developer_input_tokens: 250000
   directory_listing_max_files: 10
   # Parallel baseline execution
   baseline_max_parallel_workers: 3  # Max baselines running in parallel when GPU isolation is disabled (ignored if enable_mig or enable_multi_gpu is true)

--- a/guardrails/code_safety.py
+++ b/guardrails/code_safety.py
@@ -13,7 +13,7 @@ Does NOT restrict file system access - trusts LLM code generation.
 import logging
 from typing import Dict, Any
 
-from tools.helpers import call_llm_with_retry_google
+from tools.helpers import call_llm
 from schemas.guardrails import CodeSafetyCheck
 from prompts.guardrails import code_safety_system, code_safety_user
 from project_config import get_config
@@ -49,7 +49,7 @@ def check_code_safety(code: str) -> Dict[str, Any]:
         system_prompt = code_safety_system()
         user_prompt = code_safety_user(code)
 
-        response = call_llm_with_retry_google(
+        response = call_llm(
             model=_SAFETY_MODEL,
             system_instruction=system_prompt,
             messages=user_prompt,

--- a/guardrails/developer.py
+++ b/guardrails/developer.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, List, Optional
 from dotenv import load_dotenv
 from project_config import get_config
 
-from tools.helpers import call_llm_with_retry, call_llm_with_retry_anthropic, call_llm_with_retry_google
+from tools.helpers import call_llm
 from prompts.guardrails import leakage_review as prompt_leakage_review
-from utils.llm_utils import detect_provider, append_message
+from utils.llm_utils import append_message
 from schemas.guardrails import LeakageReviewResponse
 
 
@@ -145,32 +145,12 @@ def llm_leakage_review(code: str) -> LeakageReviewResponse:
     Uses the configured leakage review model. Returns structured LeakageReviewResponse.
     """
     system_prompt = prompt_leakage_review()
-    provider = detect_provider(_LEAKAGE_REVIEW_MODEL)
-    messages = [append_message(provider, "user", "Python Training Script: \n\n" + code)]
+    messages = [append_message("user", "Python Training Script: \n\n" + code)]
 
-    if provider == "openai":
-        return call_llm_with_retry(
-            model=_LEAKAGE_REVIEW_MODEL,
-            instructions=system_prompt,
-            tools=[],
-            messages=messages,
-            text_format=LeakageReviewResponse,
-        )
-    elif provider == "anthropic":
-        return call_llm_with_retry_anthropic(
-            model=_LEAKAGE_REVIEW_MODEL,
-            instructions=system_prompt,
-            tools=[],
-            messages=messages,
-            text_format=LeakageReviewResponse,
-        )
-    elif provider == "google":
-        return call_llm_with_retry_google(
-            model=_LEAKAGE_REVIEW_MODEL,
-            system_instruction=system_prompt,
-            function_declarations=[],
-            messages=messages,
-            text_format=LeakageReviewResponse,
-        )
-    else:
-        raise ValueError(f"Unsupported provider: {provider}")
+    return call_llm(
+        model=_LEAKAGE_REVIEW_MODEL,
+        system_instruction=system_prompt,
+        function_declarations=[],
+        messages=messages,
+        text_format=LeakageReviewResponse,
+    )

--- a/project_config.py
+++ b/project_config.py
@@ -12,11 +12,11 @@ import yaml
 
 _DEFAULT_CONFIG: dict[str, Any] = {
     "llm": {
-        "developer_model": "gpt-5",
-        "developer_tool_model": "gpt-5",
-        "researcher_model": "gpt-5",
-        "model_selector_model": "gpt-5",
-        "model_recommender_model": "gpt-5",
+        "developer_model": "gemini-3-pro-preview",
+        "developer_tool_model": "gemini-3-pro-preview",
+        "researcher_model": "gemini-3-pro-preview",
+        "model_selector_model": "gemini-3-pro-preview",
+        "model_recommender_model": "gemini-3-pro-preview",
     },
     "runtime": {
         "researcher_max_steps": 512,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,31 +1,13 @@
-# Minimal dependencies for running tests
-# Tests use mocks and don't need the full ML stack
-
-# Testing framework
-pytest>=7.0
-pytest-cov>=4.0
-
-# Core dependencies that agents/tools import
-pydantic>=2.0
-openai>=1.0
-python-dotenv>=1.0
-anthropic>=0.34.0
-
-# Observability (used in agent code)
-weave>=0.50.0
-wandb>=0.16.0
-
-# Data handling (lightweight, used in some agent imports)
-pandas>=2.1
-numpy>=1.26
-
-# Kaggle integration (used in tools)
-kaggle>=1.6.0
-kagglehub>=0.2.0
-
-# Google/Gemini (used in researcher tools)
+pytest
+pytest-cov
+pydantic
+python-dotenv
+weave
+wandb
+pandas
+numpy
+kaggle
+kagglehub
 google-genai
-
-# Utilities
-PyYAML>=6.0
-requests>=2.31.0
+PyYAML
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,50 +1,26 @@
-# Minimal cross-modal baseline dependencies (offline-friendly)
-# Tabular/Text/Image/Video ingestion + training + diagnostics
-
-# Core numerical/ML stack
-numpy>=1.26
-pandas>=2.1
-scikit-learn>=1.4
-tqdm>=4.66
-rich>=13.7
-
-# Gradient-boosting (GPU-capable on supported platforms)
-xgboost>=2.0
-
-# Optional: LightGBM (avoid on macOS by default due to build frictions)
-lightgbm>=4.3; platform_system != "Darwin"
-
-# File formats and fast IO
-pyarrow>=14.0
-xmltodict>=0.13
-# PDF parsing via PyMuPDF (fitz)
-pymupdf>=1.24
-
-# Images/Video
-Pillow>=10.0
-opencv-python>=4.8
-albumentations>=1.4
-
-# Anthropic SDK for Async Messages API
-anthropic>=0.34.0
-
-# Optional helpers (uncomment if needed)
-polars>=0.20  # fast tabular EDA/processing
-catboost>=1.2
-pyyaml>=6.0
-
+numpy
+pandas
+scikit-learn
+tqdm
+rich
+xgboost
+lightgbm; platform_system != "Darwin"
+pyarrow
+xmltodict
+pymupdf
+Pillow
+opencv-python
+albumentations
+polars
+catboost
+pyyaml
 exa
 firecrawl-py
 sentence-transformers
-
-# Agents & tooling
-openai>=1.40.0
-python-dotenv>=1.0.1
-
+python-dotenv
 kaggle
 kagglehub
 nltk
-
 transformers[torch]
 torchvision
 tensorflow
@@ -53,15 +29,13 @@ peft
 bitsandbytes
 tf-keras
 sentencepiece
-
 wandb
 weave
-timm>=0.9.16
-datasets 
+timm
+datasets
 tensorboard
 matplotlib
 seaborn
 torchgeo
 scikit-image
-
 google-genai

--- a/tests/test_media_ingestion.py
+++ b/tests/test_media_ingestion.py
@@ -43,15 +43,15 @@ def test_ingest_new_media_appends_multimodal_message(tmp_path, monkeypatch):
     # Act: ingest the newly created media
     messages = agent._ingest_new_media(before)
 
-    # Assert: a message was returned with correct structure
+    # Assert: a message was returned with correct structure (Gemini format)
     assert messages is not None
     assert len(messages) == 1
     m = messages[0]
     assert m.get("role") == "user"
-    content = m.get("content")
-    assert isinstance(content, list) and len(content) >= 1
-    # At least one input_image item present (Responses API format)
-    assert any(item.get("type") == "input_image" for item in content)
+    parts = m.get("parts")
+    assert isinstance(parts, list) and len(parts) >= 1
+    # At least one Part with inline_data present (Gemini format)
+    assert any(hasattr(p, "inline_data") and p.inline_data for p in parts)
 
 
 def test_ingest_media_respects_max_images(tmp_path):
@@ -80,8 +80,8 @@ def test_ingest_media_respects_max_images(tmp_path):
 
     assert messages is not None
     assert len(messages) == 1
-    content = messages[0]["content"]
-    attached = [c for c in content if c.get("type") == "input_image"]
+    parts = messages[0]["parts"]
+    attached = [p for p in parts if hasattr(p, "inline_data") and p.inline_data]
     assert len(attached) <= MAX_IMAGES_PER_STEP
 
 

--- a/tests/test_model_recommender.py
+++ b/tests/test_model_recommender.py
@@ -17,7 +17,7 @@ from agents.model_recommender import ModelRecommenderAgent
 def patch_llm_calls(monkeypatch):
     """Mock all LLM API calls to avoid actual network requests."""
 
-    def fake_call_llm_with_retry(*args, **kwargs):
+    def fake_call_llm(*args, **kwargs):
         """Return a mock response based on the text_format (Pydantic schema).
 
         When text_format is provided, the helper returns the parsed Pydantic object directly
@@ -40,11 +40,9 @@ def patch_llm_calls(monkeypatch):
             ModelSelection,
         )
 
-        # Get the expected schema from text_format parameter
         text_format = kwargs.get('text_format')
 
         if text_format and issubclass(text_format, BaseModel):
-            # Return the Pydantic model directly (not wrapped in response object)
             if text_format.__name__ == 'PreprocessingRecommendations':
                 return text_format(
                     preprocessing=CategoryRecommendations(
@@ -96,17 +94,14 @@ def patch_llm_calls(monkeypatch):
                     )
                 )
             elif text_format.__name__ == 'ModelSelection':
-                # For model selection, return empty to trigger default behavior
                 return text_format(
                     recommended_models=[],
                 )
             else:
-                # Generic fallback
                 return text_format()
         else:
-            # For non-structured calls, return a mock with text attribute
             mock_response = MagicMock()
-            mock_response.output_text = """```json
+            mock_response.text = """```json
 {
     "preprocessing": {
         "MUST_HAVE": [
@@ -120,12 +115,7 @@ def patch_llm_calls(monkeypatch):
 ```"""
             return mock_response
 
-    # Force OpenAI provider to avoid real API calls
-    monkeypatch.setattr("agents.model_recommender.detect_provider", lambda x: "openai")
-    monkeypatch.setattr("agents.model_recommender.call_llm_with_retry", fake_call_llm_with_retry)
-    # Also mock the other providers in case detect_provider returns them
-    monkeypatch.setattr("agents.model_recommender.call_llm_with_retry_anthropic", fake_call_llm_with_retry)
-    monkeypatch.setattr("agents.model_recommender.call_llm_with_retry_google", fake_call_llm_with_retry)
+    monkeypatch.setattr("agents.model_recommender.call_llm", fake_call_llm)
 
 
 @pytest.fixture(scope='module')
@@ -163,28 +153,22 @@ def test_task_dir():
 
 def test_agent_initialization(test_task_dir, monkeypatch):
     """Test agent initialization with dummy data."""
-    # Patch the module-level _TASK_ROOT constant
     monkeypatch.setattr("agents.model_recommender._TASK_ROOT", test_task_dir['task_root'])
 
     agent = ModelRecommenderAgent(test_task_dir['slug'], test_task_dir['iteration'])
 
-    # Check paths are set correctly
     assert agent.slug == test_task_dir['slug']
     assert agent.iteration == test_task_dir['iteration']
     assert agent.outputs_dir.exists()
     assert agent.json_path.name == "model_recommendations.json"
 
-    # Check inputs were loaded
     assert "description" in agent.inputs
     assert "task_type" in agent.inputs
     assert "task_summary" in agent.inputs
     assert "plan" in agent.inputs
 
-    # Check task_type is a list
     assert isinstance(agent.inputs["task_type"], list)
     assert "nlp" in agent.inputs["task_type"]
-
-    # Check description is not empty
     assert len(agent.inputs["description"]) > 0
 
     print(f"✅ Agent initialized successfully:")
@@ -195,26 +179,18 @@ def test_agent_initialization(test_task_dir, monkeypatch):
 
 def test_recommend_for_model(test_task_dir, monkeypatch):
     """Test generating recommendations for a single model."""
-    # Patch the module-level _TASK_ROOT constant
     monkeypatch.setattr("agents.model_recommender._TASK_ROOT", test_task_dir['task_root'])
 
     agent = ModelRecommenderAgent(test_task_dir['slug'], test_task_dir['iteration'])
 
-    # Test recommendation generation (should use mocked LLM calls)
     recommendations = agent._recommend_for_model("deberta-v3-large")
 
-    # Check structure - recommendations should have expected keys
-    # Note: Keys may vary based on implementation (preprocessing, data_augmentation, etc)
     assert isinstance(recommendations, dict)
     assert len(recommendations) > 0
 
-    # Check that values are dicts
     for key, value in recommendations.items():
         assert isinstance(value, dict), f"Value for {key} should be dict"
 
-    # Verify at least some expected categories exist
-    # The structure may include preprocessing, loss_function, hyperparameters, inference_strategies
-    # or data_augmentation, etc. depending on the model
     expected_some_of = ["preprocessing", "loss_function", "hyperparameters", "inference_strategies", "data_augmentation"]
     found_keys = [k for k in expected_some_of if k in recommendations]
     assert len(found_keys) > 0, f"Expected at least one of {expected_some_of}, got {list(recommendations.keys())}"

--- a/tests/test_researcher_agent.py
+++ b/tests/test_researcher_agent.py
@@ -85,12 +85,12 @@ def test_agent_initialization(test_task_dir, monkeypatch):
 
 
 # NOTE: test_build_plan_with_tool_calls has been removed as it requires extensive
-# mocking of complex OpenAI API response formats. The core functionality is tested
+# mocking of complex Gemini API response formats. The core functionality is tested
 # through integration tests.
 
 
 # NOTE: test_build_plan_direct_output has been removed as it requires extensive
-# mocking of complex OpenAI API response formats. The core functionality is tested
+# mocking of complex Gemini API response formats. The core functionality is tested
 # through integration tests.
 
 
@@ -125,11 +125,11 @@ def test_read_starter_suggestions(test_task_dir, monkeypatch):
 
 
 # NOTE: test_researcher_build_plan_invalid_tool_arguments has been removed as it requires
-# extensive mocking of complex OpenAI API response formats.
+# extensive mocking of complex Gemini API response formats.
 
 
 # NOTE: test_researcher_build_plan_empty_tool_results has been removed as it requires
-# extensive mocking of complex OpenAI API response formats.
+# extensive mocking of complex Gemini API response formats.
 
 
 # Tests for extracted methods after refactoring

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -1,5 +1,5 @@
 """
-LLM utility functions for provider detection and response handling.
+LLM utility functions for Gemini response handling and tool definitions.
 """
 
 import base64
@@ -10,14 +10,13 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def encode_image_to_data_url(image_path: str | Path, resize_for_anthropic: bool = False, max_size_bytes: int = 4_500_000) -> str:
+def encode_image_to_data_url(image_path: str | Path, max_size_bytes: int = 4_500_000) -> str:
     """
     Encode an image file to a data URL.
 
     Args:
         image_path: Path to the image file
-        resize_for_anthropic: Whether to resize image to max 2000px per dimension (for Anthropic API)
-        max_size_bytes: Maximum file size in bytes (default 4.5MB to stay under Anthropic's 5MB limit)
+        max_size_bytes: Maximum file size in bytes (default 4.5MB)
 
     Returns:
         Data URL string in format: data:{mime};base64,{data}
@@ -26,9 +25,6 @@ def encode_image_to_data_url(image_path: str | Path, resize_for_anthropic: bool 
     Examples:
         >>> encode_image_to_data_url("chart.png")
         'data:image/png;base64,iVBORw0KGgo...'
-
-        >>> encode_image_to_data_url("large_chart.jpg", resize_for_anthropic=True)
-        'data:image/jpeg;base64,/9j/4AAQSkZJRg...'
     """
     path = Path(image_path) if isinstance(image_path, str) else image_path
 
@@ -50,70 +46,6 @@ def encode_image_to_data_url(image_path: str | Path, resize_for_anthropic: bool 
     try:
         image_bytes = path.read_bytes()
 
-        # Resize/compress image if needed for Anthropic
-        if resize_for_anthropic:
-            try:
-                from PIL import Image
-                import io
-
-                img = Image.open(io.BytesIO(image_bytes))
-                width, height = img.size
-                original_size = len(image_bytes)
-                resized = False
-
-                # Check if resizing is needed (dimensions)
-                if width > 2000 or height > 2000:
-                    # Calculate new dimensions maintaining aspect ratio
-                    if width > height:
-                        new_width = 2000
-                        new_height = int(height * (2000 / width))
-                    else:
-                        new_height = 2000
-                        new_width = int(width * (2000 / height))
-
-                    # Resize the image
-                    img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-                    resized = True
-                    logger.info(f"Resized image {path.name} from {width}x{height} to {new_width}x{new_height}")
-
-                # Save to bytes (convert PNG to JPEG if too large)
-                output = io.BytesIO()
-
-                # Try saving as original format first
-                if img.mode == 'RGBA':
-                    # Convert RGBA to RGB for JPEG
-                    img = img.convert('RGB')
-
-                # Save as JPEG with quality adjustment to meet size limit
-                quality = 95
-                while quality >= 20:
-                    output = io.BytesIO()
-                    img.save(output, format='JPEG', quality=quality, optimize=True)
-                    image_bytes = output.getvalue()
-
-                    if len(image_bytes) <= max_size_bytes:
-                        if quality < 95 or resized:
-                            logger.info(f"Compressed image {path.name}: {original_size/1024/1024:.2f}MB -> {len(image_bytes)/1024/1024:.2f}MB (quality={quality})")
-                        mime = "image/jpeg"  # Update mime type since we converted to JPEG
-                        break
-                    quality -= 10
-                else:
-                    # Still too large after max compression, resize further
-                    current_width, current_height = img.size
-                    new_width = int(current_width * 0.5)
-                    new_height = int(current_height * 0.5)
-                    img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-                    output = io.BytesIO()
-                    img.save(output, format='JPEG', quality=50, optimize=True)
-                    image_bytes = output.getvalue()
-                    mime = "image/jpeg"
-                    logger.warning(f"Aggressively compressed image {path.name} to {len(image_bytes)/1024/1024:.2f}MB")
-
-            except ImportError:
-                logger.warning("PIL not available for image resizing. Image may fail if too large.")
-            except Exception as e:
-                logger.warning(f"Failed to resize image {path.name}: {e}. Using original.")
-
         # Final size check
         if len(image_bytes) > max_size_bytes:
             logger.error(f"Image {path.name} exceeds size limit ({len(image_bytes)/1024/1024:.2f}MB > {max_size_bytes/1024/1024:.2f}MB). Skipping.")
@@ -127,232 +59,50 @@ def encode_image_to_data_url(image_path: str | Path, resize_for_anthropic: bool 
     return f"data:{mime};base64,{data}"
 
 
-def detect_provider(model_name: str) -> str:
+def extract_text_from_response(response) -> str:
     """
-    Detect LLM provider from model name.
+    Extract text from a Gemini response.
 
     Args:
-        model_name: Model identifier (e.g., "gpt-5", "claude-sonnet-4-5-20250929", "gemini-2.5-pro")
-
-    Returns:
-        "openai" | "anthropic" | "gemini"
-
-    Raises:
-        ValueError: If provider cannot be determined
-
-    Examples:
-        >>> detect_provider("gpt-5")
-        'openai'
-        >>> detect_provider("claude-sonnet-4-5-20250929")
-        'anthropic'
-        >>> detect_provider("gemini-2.5-pro")
-        'gemini'
-    """
-    if model_name.startswith("gpt-") or model_name.startswith("o"):
-        return "openai"
-    elif model_name.startswith("claude-"):
-        return "anthropic"
-    elif model_name.startswith("gemini-"):
-        return "google"
-    else:
-        raise ValueError(f"Unknown provider for model: {model_name}")
-
-
-def extract_text_from_response(response, provider: str) -> str:
-    """
-    Extract text from provider-specific response format.
-
-    Args:
-        response: OpenAI, Anthropic, or Google response object
-        provider: "openai", "anthropic", or "google"
+        response: Google Gemini response object
 
     Returns:
         Extracted text string
 
-    Raises:
-        ValueError: If provider is not supported
-
     Examples:
-        # OpenAI response
-        >>> text = extract_text_from_response(openai_response, "openai")
-
-        # Anthropic response
-        >>> text = extract_text_from_response(anthropic_response, "anthropic")
-
-        # Google/Gemini response
-        >>> text = extract_text_from_response(gemini_response, "google")
+        >>> text = extract_text_from_response(gemini_response)
     """
-    if provider == "openai":
-        return response.output_text
+    return response.text if hasattr(response, 'text') else str(response)
 
-    elif provider == "anthropic":
-        # Concatenate all text blocks from content
-        text_blocks = [
-            block.text for block in response.content
-            if hasattr(block, 'text')
-        ]
-        return ''.join(text_blocks)
 
-    elif provider == "google":
-        # For Gemini, response.text contains the generated text
-        return response.text if hasattr(response, 'text') else str(response)
-
-    else:
-        raise ValueError(f"Unsupported provider: {provider}")
-
-def append_message(provider: str, role: str, message: str) -> dict:
+def append_message(role: str, message: str) -> dict:
     """
-    Create a message in provider-specific format.
+    Create a message in Gemini format.
 
     Args:
-        provider: "openai", "anthropic", or "google"
         role: Message role ("user", "assistant", "model", etc.)
         message: Message content (text string)
 
     Returns:
-        Formatted message dict for the provider
+        Formatted message dict for Gemini
 
     Examples:
-        >>> append_message("openai", "user", "Hello")
-        {'role': 'user', 'content': 'Hello'}
-
-        >>> append_message("google", "user", "Hello")
+        >>> append_message("user", "Hello")
         {'role': 'user', 'parts': [{'text': 'Hello'}]}
 
-        >>> append_message("google", "assistant", "Hi")
+        >>> append_message("assistant", "Hi")
         {'role': 'model', 'parts': [{'text': 'Hi'}]}
     """
-    if provider == "google":
-        # Gemini uses "model" instead of "assistant"
-        gemini_role = "model" if role == "assistant" else role
-        return {"role": gemini_role, "parts": [{"text": message}]}
-    else:
-        # OpenAI and Anthropic use same format
-        return {"role": role, "content": message}
+    gemini_role = "model" if role == "assistant" else role
+    return {"role": gemini_role, "parts": [{"text": message}]}
 
 
-def get_tools_openai():
+def get_tools():
     """
-    Get tools in OpenAI format.
+    Get tools as Gemini FunctionDeclaration objects.
 
     Returns:
-        List of tool definitions in OpenAI format
-    """
-    return [
-        {
-            "type": "function",
-            "name": "execute_python",
-            "description": "Write and execute a Python script. The script runs in the task data directory with access to all data files, model outputs, and predictions. Print results to stdout.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "code": {"type": "string", "description": "Complete Python script to execute."}
-                },
-            },
-            "additionalProperties": False,
-            "required": ['code']
-        },
-        {
-            "type": "function",
-            "name": "read_research_paper",
-            "description": "Read and summarize a research paper from arxiv. Returns structured markdown summary with Abstract, Introduction, Related Work, Method/Architecture, Experiments/Results, and Conclusion sections.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "arxiv_link": {"type": "string", "description": "ArXiv paper link (e.g., 'https://arxiv.org/pdf/2510.22916' or just '2510.22916')"}
-                },
-            },
-            "additionalProperties": False,
-            "required": ["arxiv_link"],
-        },
-        {
-            "type": "function",
-            "name": "scrape_web_page",
-            "description": "Scrape a web page and return markdown content. Useful for reading blog posts, documentation, technical tutorials, and other domain-specific web content that complements arxiv papers.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "url": {"type": "string", "description": "The webpage URL to scrape (e.g., 'https://developer.nvidia.com/blog/...')"}
-                },
-            },
-            "additionalProperties": False,
-            "required": ["url"],
-        },
-    ]
-
-
-def get_tools_anthropic():
-    """
-    Get tools in Anthropic format.
-
-    Key differences from OpenAI format:
-    - No nested "function" wrapper
-    - Uses "input_schema" instead of "parameters"
-    - 3-4 sentence descriptions (Anthropic best practice)
-
-    Returns:
-        List of tool definitions in Anthropic format
-    """
-    return [
-        {
-            "name": "execute_python",
-            "description": """Write and execute a Python script. The script runs in the task data directory
-            with access to all data files, model outputs, and predictions. Use this for exploratory data analysis,
-            debugging, downloading external datasets, or any data investigation. Print results to stdout.""",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "description": "Complete Python script to execute."
-                    }
-                },
-                "required": ["code"]
-            }
-        },
-        {
-            "name": "read_research_paper",
-            "description": """Read and summarize academic research papers from arXiv relevant to the machine learning task.
-            Returns structured markdown summary with Abstract, Introduction, Related Work, Method/Architecture,
-            Experiments/Results, and Conclusion sections. Use this to discover state-of-the-art techniques,
-            validate your approach against published research, or find novel methods applicable to your problem.""",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "arxiv_link": {
-                        "type": "string",
-                        "description": "ArXiv paper link (e.g., 'https://arxiv.org/pdf/2510.22916' or just '2510.22916')"
-                    }
-                },
-                "required": ["arxiv_link"]
-            }
-        },
-        {
-            "name": "scrape_web_page",
-            "description": """Scrape web pages and return markdown content from technical documentation, blog posts,
-            and tutorials. Useful for accessing domain-specific knowledge, implementation guides, or best practices
-            that complement academic papers. Use this to gather practical insights from developer blogs, official
-            documentation, or technical articles that can inform your modeling approach.""",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "url": {
-                        "type": "string",
-                        "description": "The webpage URL to scrape (e.g., 'https://developer.nvidia.com/blog/...')"
-                    }
-                },
-                "required": ["url"]
-            }
-        }
-    ]
-
-
-def get_tools_gemini():
-    """
-    Get tools in Gemini format (FunctionDeclaration).
-
-    Returns:
-        List of FunctionDeclaration objects for Gemini
+        List of FunctionDeclaration objects
     """
     from google.genai import types
 
@@ -402,73 +152,12 @@ def get_tools_gemini():
     ]
 
 
-def get_tools_for_provider(provider: str):
-    """
-    Get tools in the appropriate format for the provider.
-
-    Args:
-        provider: "openai", "anthropic", or "google"
-
-    Returns:
-        List of tool definitions in provider-specific format
-
-    Raises:
-        ValueError: If provider is not supported
-    """
-    if provider == "openai":
-        return get_tools_openai()
-    elif provider == "anthropic":
-        return get_tools_anthropic()
-    elif provider == "google":
-        return get_tools_gemini()
-    else:
-        raise ValueError(f"Unsupported provider: {provider}")
-
-
 # ---------------------------------------------------------------------------
 # Monitor tools (execute_bash for system diagnostics during training)
 # ---------------------------------------------------------------------------
 
-def get_monitor_tools_openai():
-    return [
-        {
-            "type": "function",
-            "name": "execute_bash",
-            "description": "Execute a bash command for system diagnostics. Use for checking GPU utilization (nvidia-smi), process status (ps, top), memory (free), disk (df), etc.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "command": {"type": "string", "description": "Bash command to execute."}
-                },
-            },
-            "additionalProperties": False,
-            "required": ["command"],
-        }
-    ]
-
-
-def get_monitor_tools_anthropic():
-    return [
-        {
-            "name": "execute_bash",
-            "description": """Execute a bash command for system diagnostics. Use for checking GPU utilization
-            (nvidia-smi), process status (ps, top), memory usage (free), disk space (df), and other
-            read-only system inspection commands. Do not use for modifying system state.""",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "Bash command to execute."
-                    }
-                },
-                "required": ["command"]
-            }
-        }
-    ]
-
-
-def get_monitor_tools_gemini():
+def get_monitor_tools():
+    """Get monitor tools (execute_bash) as Gemini FunctionDeclaration objects."""
     from google.genai import types
 
     return [
@@ -487,15 +176,3 @@ def get_monitor_tools_gemini():
             }
         )
     ]
-
-
-def get_monitor_tools_for_provider(provider: str):
-    """Get monitor tools (execute_bash) in the appropriate format for the provider."""
-    if provider == "openai":
-        return get_monitor_tools_openai()
-    elif provider == "anthropic":
-        return get_monitor_tools_anthropic()
-    elif provider == "google":
-        return get_monitor_tools_gemini()
-    else:
-        raise ValueError(f"Unsupported provider: {provider}")


### PR DESCRIPTION
## Summary
- Remove all OpenAI and Anthropic provider support — codebase now exclusively uses Google Gemini
- Remove `detect_provider()` dispatch function and all `if provider == "openai"` / `elif provider == "anthropic"` / `elif provider == "google"` branching throughout the codebase
- Rename `call_llm_with_retry_google()` → `call_llm()`, `get_tools_gemini()` → `get_tools()`, `get_monitor_tools_gemini()` → `get_monitor_tools()`
- Simplify `append_message()` and `extract_text_from_response()` by removing `provider` parameter — Gemini format runs unconditionally
- Remove `resize_for_anthropic` parameter from `encode_image_to_data_url()`
- Remove `openai` and `anthropic` from `requirements.txt`
- Update all test files and demos to match simplified API

## Test plan
- [x] `pytest tests/test_starter_agent.py tests/test_model_recommender.py tests/test_developer_tools.py tests/test_researcher_agent.py -v` — 24 tests pass
- [x] `python demos/test_hitl_message_injection.py` — 3 Gemini injection tests pass
- [x] All module imports verified (`agents/starter`, `agents/researcher`, `agents/developer`, `agents/model_recommender`, `guardrails/developer`, `guardrails/code_safety`, `tools/generate_paper_summary`, `tools/helpers`, `utils/llm_utils`)
- [x] Grep confirms zero remaining references to `detect_provider`, `call_llm_with_retry`, `resize_for_anthropic`, `get_tools_for_provider` in production code
