### PR TITLE
remove CodeGeneration structured output to fix syntax errors in generated code

### DIFF
--- a/prompts/developer_agent.py
+++ b/prompts/developer_agent.py
@@ -106,7 +106,7 @@ def build_system(
 
 Return a single Python script within ```python backticks.
 
-Start the file with a docstring containing a 3-7 bullet point checklist of your approach.
+Start the file with a docstring containing your reasoning and approach.
 
 ### Required Artifacts
 The script must save these files to the paths specified in the user prompt:

--- a/schemas/developer.py
+++ b/schemas/developer.py
@@ -38,12 +38,3 @@ class RedFlagsResponse(BaseModel):
     log_issues: str
     web_search_findings: str
     final_summary: str
-
-
-class CodeGeneration(BaseModel):
-    """Schema for generating training code in folder structure.
-
-    The train_py field should contain the complete training script.
-    """
-    reasoning: str
-    train_py: str


### PR DESCRIPTION
## Summary

- Remove `CodeGeneration` structured output for code generation — structured JSON output causes the model to leak JSON/markdown delimiters (`"""`, `}`, ` ``` `) into the `train_py` field after generating 300+ lines of code, producing syntax errors that crash the guardrail AST parser
- `_generate_code` now uses free-text output with ` ```python ` markdown fences (which the prompt already requested), extracted by `extract_python_code()` with compile checks
- `_write_code` takes a `str` instead of `dict[str, str]` — the `code_dict` indirection was unnecessary
- Prompt updated: docstring "checklist" → "reasoning and approach"

## Test plan

- [x] All 34 tests pass
- [ ] Run a full competition to verify code generation works end-to-end
