### PR TITLE
add library investigator sub-agent for codebase analysis (#111)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ llm:
   starter_model: "gemini-3.1-pro-preview"
   leakage_review_model: "gemini-3.1-pro-preview"
   finetuned_code_api_model: "gemini-3.1-pro-preview"
+  library_investigator_model: "gemini-3.1-pro-preview"
 runtime:
   researcher_max_steps: 512
   llm_max_retries: 5
@@ -31,6 +32,7 @@ runtime:
   use_validation_score: true  # If true, use validation score from logs instead of MLE-bench grading (faster, no ground truth needed)
   is_lower_better: false  # Metric direction: true if lower scores are better (e.g. MSE), false if higher is better (e.g. R²)
   gold_threshold: null  # Target score to reach (null = no target)
+  library_investigator_max_steps: 15
 paths:
   task_root: "task"
   outputs_dirname: "outputs"

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -1,9 +1,11 @@
 from . import developer_agent as developer_agent
 from . import researcher_agent as researcher_agent
 from . import tools_developer as tools_developer
+from . import library_investigator as library_investigator
 
 __all__ = [
     "developer_agent",
     "researcher_agent",
     "tools_developer",
+    "library_investigator",
 ]

--- a/prompts/library_investigator.py
+++ b/prompts/library_investigator.py
@@ -1,0 +1,44 @@
+"""Prompts for the library investigator sub-agent."""
+
+import sysconfig
+
+SITE_PACKAGES_PATH = sysconfig.get_path("purelib")
+
+
+def build_system() -> str:
+    return f"""You are a library API investigator. Your job is to explore Python library \
+source code installed at `{SITE_PACKAGES_PATH}` and produce an accurate report about the \
+actual API surfaces relevant to the user's query.
+
+## Approach
+
+1. Start by listing packages to find the relevant library directories.
+2. Use glob_files to map the package structure (look for __init__.py, key modules).
+3. Read __init__.py files to find public API exports (__all__, direct imports).
+4. Read specific source files to extract:
+   - Class definitions and their __init__ signatures (exact parameter names, types, defaults)
+   - Key method signatures
+   - Dataclass/config class fields
+5. Follow import chains when a class re-exports from a submodule.
+
+## Rules
+
+- Report ONLY what you find in the source code. Never guess or hallucinate API details.
+- If a parameter has a default value, include it exactly as written.
+- If a class inherits from another, note the parent class.
+- Focus on the classes and functions directly relevant to the query.
+- If the library is not installed, report that immediately and stop.
+
+## Investigation Strategy
+
+Track which packages you have identified as relevant, which files you have read, and \
+what questions remain. Stop once you have enough information to fully answer the query."""
+
+
+def build_user(query: str) -> str:
+    return f"""Investigate the installed library source code to answer this query:
+
+{query}
+
+Use the provided tools to explore the actual source code in site-packages. \
+Return your findings as structured output."""

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -11,6 +11,7 @@ from schemas.developer import (
     StackTraceSolution,
     SOTAResponse,
 )
+from schemas.library_investigator import LibraryInvestigatorReport
 
 __all__ = [
     "StarterSuggestions",
@@ -20,4 +21,5 @@ __all__ = [
     "InferenceStrategyRecommendations",
     "StackTraceSolution",
     "SOTAResponse",
+    "LibraryInvestigatorReport",
 ]

--- a/schemas/library_investigator.py
+++ b/schemas/library_investigator.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class LibraryInvestigatorReport(BaseModel):
+    """Structured report from investigating library source code in site-packages."""
+
+    packages_examined: str
+    api_surface: str
+    constructor_signatures: str
+    key_methods: str
+    usage_patterns: str
+    caveats: str

--- a/tools/library_investigator.py
+++ b/tools/library_investigator.py
@@ -1,0 +1,285 @@
+"""Library source code investigator sub-agent.
+
+Explores installed Python packages in site-packages to produce accurate API
+reports. Called by the DeveloperAgent as a tool during code generation.
+"""
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+from google.genai import types
+from project_config import get_config
+from tools.helpers import call_llm
+from utils.llm_utils import append_message, get_library_investigator_tools
+from schemas.library_investigator import LibraryInvestigatorReport
+from prompts.library_investigator import build_system, build_user, SITE_PACKAGES_PATH
+
+logger = logging.getLogger(__name__)
+
+_CONFIG = get_config()
+_LLM_CFG = _CONFIG["llm"]
+_RUNTIME_CFG = _CONFIG["runtime"]
+_LIBRARY_INVESTIGATOR_MODEL = _LLM_CFG["library_investigator_model"]
+_MAX_TOOL_STEPS = _RUNTIME_CFG["library_investigator_max_steps"]
+
+_SITE_PACKAGES = Path(SITE_PACKAGES_PATH).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations (read-only, scoped to site-packages)
+# ---------------------------------------------------------------------------
+
+
+def _validate_site_packages_path(path: Path) -> str | None:
+    """Return an error string if the resolved path escapes site-packages."""
+    resolved = path.resolve()
+    if not str(resolved).startswith(str(_SITE_PACKAGES)):
+        return "Path escapes site-packages directory"
+    return None
+
+
+def _tool_list_packages() -> str:
+    if not _SITE_PACKAGES.exists():
+        return json.dumps({"error": f"Site-packages not found at {SITE_PACKAGES_PATH}"})
+
+    packages = sorted(
+        d.name
+        for d in _SITE_PACKAGES.iterdir()
+        if d.is_dir()
+        and not d.name.startswith("_")
+        and not d.name.startswith(".")
+        and not d.name.endswith(".dist-info")
+        and not d.name.endswith(".egg-info")
+    )
+    return json.dumps({"packages": packages, "count": len(packages)})
+
+
+def _tool_read_file(
+    path: str, start_line: int | None = None, end_line: int | None = None
+) -> str:
+    full_path = _SITE_PACKAGES / path
+    error = _validate_site_packages_path(full_path)
+    if error:
+        return json.dumps({"error": error})
+
+    resolved = full_path.resolve()
+    if not resolved.exists():
+        return json.dumps({"error": f"File not found: {path}"})
+    if not resolved.is_file():
+        return json.dumps({"error": f"Not a file: {path}"})
+
+    try:
+        lines = resolved.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception as e:
+        return json.dumps({"error": f"Failed to read file: {e}"})
+
+    total_lines = len(lines)
+
+    if start_line is not None or end_line is not None:
+        s = (start_line or 1) - 1
+        e = end_line or total_lines
+        lines = lines[s:e]
+        line_offset = s + 1
+    else:
+        line_offset = 1
+        if total_lines > 300:
+            lines = lines[:300]
+            numbered = "\n".join(
+                f"{i + line_offset}: {line}" for i, line in enumerate(lines)
+            )
+            return json.dumps(
+                {
+                    "content": numbered,
+                    "total_lines": total_lines,
+                    "truncated": True,
+                    "showing": "1-300",
+                }
+            )
+
+    numbered = "\n".join(
+        f"{i + line_offset}: {line}" for i, line in enumerate(lines)
+    )
+    return json.dumps({"content": numbered, "total_lines": total_lines})
+
+
+def _tool_glob_files(package: str, pattern: str) -> str:
+    package_dir = _SITE_PACKAGES / package
+    error = _validate_site_packages_path(package_dir)
+    if error:
+        return json.dumps({"error": error})
+
+    resolved = package_dir.resolve()
+    if not resolved.exists():
+        return json.dumps({"error": f"Package directory not found: {package}"})
+
+    matches = sorted(str(p.relative_to(resolved)) for p in resolved.glob(pattern))
+    total = len(matches)
+    if total > 50:
+        matches = matches[:50]
+
+    return json.dumps({"matches": matches, "total": total, "truncated": total > 50})
+
+
+def _tool_grep_code(package: str, pattern: str, max_results: int = 20) -> str:
+    package_dir = _SITE_PACKAGES / package
+    error = _validate_site_packages_path(package_dir)
+    if error:
+        return json.dumps({"error": error})
+
+    resolved = package_dir.resolve()
+    if not resolved.exists():
+        return json.dumps({"error": f"Package directory not found: {package}"})
+
+    try:
+        result = subprocess.run(
+            ["grep", "-rn", "--include=*.py", "-E", pattern, str(resolved)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = result.stdout.strip().splitlines()
+    except subprocess.TimeoutExpired:
+        return json.dumps({"error": "Search timed out"})
+    except Exception as e:
+        return json.dumps({"error": f"Search failed: {e}"})
+
+    site_packages_str = str(_SITE_PACKAGES)
+    cleaned = [
+        line.replace(site_packages_str + "/", "") for line in lines[:max_results]
+    ]
+
+    return json.dumps(
+        {
+            "matches": cleaned,
+            "total_matches": len(lines),
+            "showing": min(max_results, len(lines)),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _execute_tool_call(item) -> str:
+    args = dict(item.args)
+
+    if item.name == "list_packages":
+        return _tool_list_packages()
+    elif item.name == "read_file":
+        return _tool_read_file(
+            args["path"],
+            args.get("start_line"),
+            args.get("end_line"),
+        )
+    elif item.name == "glob_files":
+        return _tool_glob_files(args["package"], args["pattern"])
+    elif item.name == "grep_code":
+        return _tool_grep_code(
+            args["package"], args["pattern"], args.get("max_results", 20)
+        )
+    else:
+        return json.dumps({"error": f"Unknown tool: {item.name}"})
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def investigate_library(query: str) -> str:
+    """Run the library investigator sub-agent and return a formatted report.
+
+    Args:
+        query: Natural language query about library APIs.
+
+    Returns:
+        Formatted string report of the investigation findings.
+    """
+    logger.info("Starting library investigation: %s", query[:100])
+
+    system_prompt = build_system()
+    user_prompt = build_user(query)
+    tools = get_library_investigator_tools()
+    input_list = [append_message("user", user_prompt)]
+
+    for step in range(_MAX_TOOL_STEPS):
+        is_last_step = step == _MAX_TOOL_STEPS - 1
+
+        logger.info("Library investigator step %d/%d", step + 1, _MAX_TOOL_STEPS)
+
+        response = call_llm(
+            model=_LIBRARY_INVESTIGATOR_MODEL,
+            system_instruction=system_prompt,
+            function_declarations=tools if not is_last_step else [],
+            messages=input_list,
+            text_format=LibraryInvestigatorReport if is_last_step else None,
+        )
+
+        # Structured output on last step
+        if hasattr(response, "packages_examined"):
+            logger.info("Library investigation completed at step %d", step + 1)
+            return _format_report(response)
+
+        parts = response.candidates[0].content.parts
+        has_function_calls = any(
+            part.function_call for part in parts if hasattr(part, "function_call")
+        )
+
+        if not has_function_calls:
+            logger.info(
+                "No function calls at step %d, requesting structured output", step + 1
+            )
+            response = call_llm(
+                model=_LIBRARY_INVESTIGATOR_MODEL,
+                system_instruction=system_prompt,
+                messages=input_list,
+                text_format=LibraryInvestigatorReport,
+            )
+            return _format_report(response)
+
+        function_responses = []
+        for part in parts:
+            if hasattr(part, "function_call") and part.function_call:
+                tool_result_str = _execute_tool_call(part.function_call)
+                function_responses.append(
+                    types.Part.from_function_response(
+                        name=part.function_call.name,
+                        response={"result": tool_result_str},
+                    )
+                )
+
+        input_list.append(response.candidates[0].content)
+        if function_responses:
+            input_list.append(
+                types.Content(role="function", parts=function_responses)
+            )
+
+    # Exhausted steps
+    logger.warning(
+        "Library investigator exhausted %d steps, forcing final report",
+        _MAX_TOOL_STEPS,
+    )
+    response = call_llm(
+        model=_LIBRARY_INVESTIGATOR_MODEL,
+        system_instruction=system_prompt
+        + "\n\nReturn your findings now based on what you have gathered.",
+        messages=input_list,
+        text_format=LibraryInvestigatorReport,
+    )
+    return _format_report(response)
+
+
+def _format_report(report: LibraryInvestigatorReport) -> str:
+    return (
+        f"## Library Investigation Report\n\n"
+        f"**Packages examined:** {report.packages_examined}\n\n"
+        f"### API Surface\n{report.api_surface}\n\n"
+        f"### Constructor Signatures\n{report.constructor_signatures}\n\n"
+        f"### Key Methods\n{report.key_methods}\n\n"
+        f"### Usage Patterns\n{report.usage_patterns}\n\n"
+        f"### Caveats\n{report.caveats}"
+    )

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -165,3 +165,112 @@ def get_monitor_tools():
             },
         )
     ]
+
+
+# ---------------------------------------------------------------------------
+# Library investigator tools (read-only, scoped to site-packages)
+# ---------------------------------------------------------------------------
+
+
+def get_library_investigator_tools():
+    """Get tools for the library investigator sub-agent.
+
+    Four read-only tools scoped to the venv's site-packages directory.
+    """
+    return [
+        types.FunctionDeclaration(
+            name="list_packages",
+            description="List all installed Python packages in the virtual environment's site-packages directory. Returns package directory names (excludes dist-info, egg-info, and private directories).",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        types.FunctionDeclaration(
+            name="read_file",
+            description="Read a Python source file from site-packages. Path is relative to site-packages (e.g., 'transformers/trainer.py'). Returns numbered lines. Files over 300 lines are truncated unless start_line/end_line are specified.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to site-packages (e.g., 'trl/trainer/sft_trainer.py')",
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "description": "Start line number (1-indexed). Optional.",
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "description": "End line number (1-indexed, inclusive). Optional.",
+                    },
+                },
+                "required": ["path"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="glob_files",
+            description="Find files matching a glob pattern within a package directory. For example, glob_files('transformers', '**/*trainer*.py') finds all trainer-related files.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "package": {
+                        "type": "string",
+                        "description": "Package directory name (e.g., 'transformers', 'trl')",
+                    },
+                    "pattern": {
+                        "type": "string",
+                        "description": "Glob pattern (e.g., '**/*.py', '**/sft*.py')",
+                    },
+                },
+                "required": ["package", "pattern"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="grep_code",
+            description="Search for a regex pattern in Python source files within a package. Returns matching lines with file paths and line numbers.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "package": {
+                        "type": "string",
+                        "description": "Package directory name (e.g., 'transformers', 'xgboost')",
+                    },
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regular expression pattern to search for (e.g., 'class SFTTrainer', 'def forward')",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of matching lines to return (default: 20)",
+                    },
+                },
+                "required": ["package", "pattern"],
+            },
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Developer tools (investigate_library for code generation)
+# ---------------------------------------------------------------------------
+
+
+def get_developer_tools():
+    """Get tools available to the DeveloperAgent during code generation."""
+    return [
+        types.FunctionDeclaration(
+            name="investigate_library",
+            description="Investigate the actual source code of an installed Python library to understand its API before writing code. A sub-agent will explore the library's source files in site-packages and return accurate constructor signatures, method signatures, and usage patterns. Use this when you need to understand how to use a library correctly.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural language query describing what you need to understand (e.g., 'How to use trl SFTTrainer with a Qwen3-4B model, including SFTConfig and data formatting')",
+                    }
+                },
+                "required": ["query"],
+            },
+        ),
+    ]


### PR DESCRIPTION
## Summary

- Add a library investigator sub-agent that reads actual installed package source code from `site-packages/` to produce accurate API reports (constructor signatures, method signatures, usage patterns)
- Expose `investigate_library` as a callable tool during `_generate_code()`, so the DeveloperAgent can query library APIs before writing code each iteration
- The sub-agent uses 4 read-only tools (`list_packages`, `read_file`, `glob_files`, `grep_code`) scoped to site-packages with path traversal protection
- Convert `_generate_code()` from a single LLM call to a tool-calling loop (max 3 investigation rounds per iteration)

## Test plan

- [x] Run `demos/test_library_investigator.py` — all 9 tool unit tests pass (list_packages, read_file, glob_files, grep_code, path traversal rejection, missing file/package handling)
- [ ] Full LLM integration test with API key: verify `investigate_library()` produces accurate reports for installed packages
- [ ] End-to-end DeveloperAgent run: confirm the model calls `investigate_library` before generating code and uses correct API signatures
