### PR TITLE
remove InferenceStrategySection wrapper and fix variable name bug (#161)

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -266,49 +266,39 @@ class DeveloperAgent:
         if preprocessing:
             sections.append("## Preprocessing NICE_TO_HAVE Recommendations")
             for category, content in preprocessing.items():
-                later_items = content["NICE_TO_HAVE"]
-                if later_items:
+                strategies = content["NICE_TO_HAVE"]
+                if strategies:
                     sections.append(f"\n### {category.replace('_', ' ').title()}")
-                    for item in later_items:
-                        if item["strategy"]:
-                            sections.append(f"- {item['strategy']}")
-                            if item["reasoning"]:
-                                sections.append(f"  {item['reasoning']}")
+                    for item in strategies:
+                        sections.append(f"- {item['strategy']}")
+                        sections.append(f"  {item['reasoning']}")
 
-        later_losses = self.later_recommendations["loss_function"]["NICE_TO_HAVE"]
-        if later_losses:
+        losses = self.later_recommendations["loss_function"]["NICE_TO_HAVE"]
+        if losses:
             sections.append("\n## Loss Function NICE_TO_HAVE Recommendations")
-            for item in later_losses:
-                if item["loss_function"]:
-                    sections.append(f"- {item['loss_function']}")
-                    if item["reasoning"]:
-                        sections.append(f"  {item['reasoning']}")
+            for item in losses:
+                sections.append(f"- {item['loss_function']}")
+                sections.append(f"  {item['reasoning']}")
 
-        later_section = self.later_recommendations["hyperparameters"]["NICE_TO_HAVE"]
-        if later_section["hyperparameters"]:
+        hyperparams = self.later_recommendations["hyperparameters"]["NICE_TO_HAVE"]
+        if hyperparams["hyperparameters"]:
             sections.append("\n## Hyperparameters NICE_TO_HAVE Recommendations")
-            for item in later_section["hyperparameters"]:
-                if item["hyperparameter"]:
-                    sections.append(f"- {item['hyperparameter']}")
-                    if item["reasoning"]:
-                        sections.append(f"  {item['reasoning']}")
+            for item in hyperparams["hyperparameters"]:
+                sections.append(f"- {item['hyperparameter']}")
+                sections.append(f"  {item['reasoning']}")
 
-        if later_section["architectures"]:
+        if hyperparams["architectures"]:
             sections.append("\n### Architecture NICE_TO_HAVE Recommendations")
-            for item in later_section["architectures"]:
-                if item["architecture"]:
-                    sections.append(f"- {item['architecture']}")
-                    if item["reasoning"]:
-                        sections.append(f"  {item['reasoning']}")
+            for item in hyperparams["architectures"]:
+                sections.append(f"- {item['architecture']}")
+                sections.append(f"  {item['reasoning']}")
 
-        inf_section = self.later_recommendations["inference_strategies"]["NICE_TO_HAVE"]
-        if inf_section["inference_strategies"]:
+        inference = self.later_recommendations["inference_strategies"]["NICE_TO_HAVE"]
+        if inference:
             sections.append("\n## Inference Strategies NICE_TO_HAVE Recommendations")
-            for item in later_section["inference_strategies"]:
-                if item["strategy"]:
-                    sections.append(f"- {item['strategy']}")
-                    if item["reasoning"]:
-                        sections.append(f"  {item['reasoning']}")
+            for item in inference:
+                sections.append(f"- {item['strategy']}")
+                sections.append(f"  {item['reasoning']}")
 
         return (
             "\n".join(sections)

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -327,20 +327,12 @@ def _extract_now_recommendations(recommendations: dict) -> dict:
         "MUST_HAVE": recommendations["loss_function"]["MUST_HAVE"]
     }
 
-    now_section = recommendations["hyperparameters"]["MUST_HAVE"]
     now_only["hyperparameters"] = {
-        "MUST_HAVE": {
-            "hyperparameters": now_section["hyperparameters"],
-            "architectures": now_section["architectures"],
-        }
+        "MUST_HAVE": recommendations["hyperparameters"]["MUST_HAVE"]
     }
 
     now_only["inference_strategies"] = {
-        "MUST_HAVE": {
-            "inference_strategies": recommendations["inference_strategies"][
-                "MUST_HAVE"
-            ]["inference_strategies"]
-        }
+        "MUST_HAVE": recommendations["inference_strategies"]["MUST_HAVE"]
     }
 
     return now_only
@@ -365,20 +357,12 @@ def _extract_later_recommendations(recommendations: dict) -> dict:
         "NICE_TO_HAVE": recommendations["loss_function"]["NICE_TO_HAVE"]
     }
 
-    later_section = recommendations["hyperparameters"]["NICE_TO_HAVE"]
     later_only["hyperparameters"] = {
-        "NICE_TO_HAVE": {
-            "hyperparameters": later_section["hyperparameters"],
-            "architectures": later_section["architectures"],
-        }
+        "NICE_TO_HAVE": recommendations["hyperparameters"]["NICE_TO_HAVE"]
     }
 
     later_only["inference_strategies"] = {
-        "NICE_TO_HAVE": {
-            "inference_strategies": recommendations["inference_strategies"][
-                "NICE_TO_HAVE"
-            ]["inference_strategies"]
-        }
+        "NICE_TO_HAVE": recommendations["inference_strategies"]["NICE_TO_HAVE"]
     }
 
     return later_only
@@ -396,31 +380,31 @@ def _format_recommendations_for_developer(recommendations: dict) -> str:
     if preprocessing:
         details.append("## Preprocessing Strategies")
         for category, content in preprocessing.items():
-            now_items = content["MUST_HAVE"]
+            strategies = content["MUST_HAVE"]
             details.append(f"\n### {category.replace('_', ' ').title()}")
-            for item in now_items:
+            for item in strategies:
                 details.append(f"- {item['strategy']}: {item['reasoning']}")
 
-    now_loss = recommendations["loss_function"]["MUST_HAVE"]
-    if now_loss["loss_function"]:
+    loss = recommendations["loss_function"]["MUST_HAVE"]
+    if loss["loss_function"]:
         details.append("\n## Loss Function")
-        details.append(f"- Use {now_loss['loss_function']}: {now_loss['reasoning']}")
+        details.append(f"- Use {loss['loss_function']}: {loss['reasoning']}")
 
-    now_section = recommendations["hyperparameters"]["MUST_HAVE"]
-    if now_section["hyperparameters"]:
+    hyperparams = recommendations["hyperparameters"]["MUST_HAVE"]
+    if hyperparams["hyperparameters"]:
         details.append("\n## Hyperparameters")
-        for item in now_section["hyperparameters"]:
+        for item in hyperparams["hyperparameters"]:
             details.append(f"- {item['hyperparameter']}: {item['reasoning']}")
 
-    if now_section["architectures"]:
+    if hyperparams["architectures"]:
         details.append("\n### Architecture Recommendations")
-        for item in now_section["architectures"]:
+        for item in hyperparams["architectures"]:
             details.append(f"- {item['architecture']}: {item['reasoning']}")
 
-    inf_section = recommendations["inference_strategies"]["MUST_HAVE"]
-    if inf_section["inference_strategies"]:
+    inference = recommendations["inference_strategies"]["MUST_HAVE"]
+    if inference:
         details.append("\n## Inference Strategies")
-        for item in inf_section["inference_strategies"]:
+        for item in inference:
             details.append(f"- {item['strategy']}: {item['reasoning']}")
 
     return "\n".join(details) if details else "No specific recommendations available."

--- a/prompts/model_recommender_agent.py
+++ b/prompts/model_recommender_agent.py
@@ -120,10 +120,9 @@ Do not search for or use actual winning solutions from this specific competition
 - **NICE_TO_HAVE**: TTA, calibration, post-processing, ensembling.
 
 ## Output
-Both MUST_HAVE and NICE_TO_HAVE contain:
-- **inference_strategies**: list of items, each with:
-  - "strategy": the inference strategy
-  - "reasoning": why
+MUST_HAVE and NICE_TO_HAVE are each a list of items with:
+- "strategy": the inference strategy
+- "reasoning": why
 """
 
 

--- a/schemas/model_recommender.py
+++ b/schemas/model_recommender.py
@@ -122,14 +122,8 @@ class InferenceStrategyItem(BaseModel):
     strategy: str
 
 
-class InferenceStrategySection(BaseModel):
-    """List of inference strategies."""
-
-    inference_strategies: list[InferenceStrategyItem]
-
-
 class InferenceStrategyRecommendations(BaseModel):
     """Schema for inference strategy recommendations."""
 
-    MUST_HAVE: InferenceStrategySection
-    NICE_TO_HAVE: InferenceStrategySection
+    MUST_HAVE: list[InferenceStrategyItem]
+    NICE_TO_HAVE: list[InferenceStrategyItem]

--- a/tests/test_model_recommender.py
+++ b/tests/test_model_recommender.py
@@ -25,7 +25,6 @@ def patch_llm_calls(monkeypatch):
             HyperparameterItem,
             ArchitectureItem,
             InferenceStrategyRecommendations,
-            InferenceStrategySection,
             InferenceStrategyItem,
             ModelSelection,
             PreprocessingRecommendations,
@@ -77,22 +76,18 @@ def patch_llm_calls(monkeypatch):
                 )
             elif text_format.__name__ == "InferenceStrategyRecommendations":
                 return text_format(
-                    MUST_HAVE=InferenceStrategySection(
-                        inference_strategies=[
-                            InferenceStrategyItem(
-                                strategy="Test-time augmentation",
-                                reasoning="Improves robustness",
-                            )
-                        ]
-                    ),
-                    NICE_TO_HAVE=InferenceStrategySection(
-                        inference_strategies=[
-                            InferenceStrategyItem(
-                                strategy="Ensemble voting",
-                                reasoning="Better predictions",
-                            )
-                        ]
-                    ),
+                    MUST_HAVE=[
+                        InferenceStrategyItem(
+                            strategy="Test-time augmentation",
+                            reasoning="Improves robustness",
+                        )
+                    ],
+                    NICE_TO_HAVE=[
+                        InferenceStrategyItem(
+                            strategy="Ensemble voting",
+                            reasoning="Better predictions",
+                        )
+                    ],
                 )
             elif text_format.__name__ == "PreprocessingRecommendations":
                 return text_format(

--- a/tests/test_orchestrator_updated.py
+++ b/tests/test_orchestrator_updated.py
@@ -84,27 +84,25 @@ def test_format_recommendations():
             "NICE_TO_HAVE": {"hyperparameters": [], "architectures": []},
         },
         "inference_strategies": {
-            "MUST_HAVE": {
-                "inference_strategies": [
-                    {
-                        "strategy": "Test-time augmentation",
-                        "reasoning": "Improve robustness",
-                    },
-                    {
-                        "strategy": "Threshold tuning",
-                        "reasoning": "Optimize for metric",
-                    },
-                    {
-                        "strategy": "Fold averaging",
-                        "reasoning": "Reduce variance",
-                    },
-                    {
-                        "strategy": "Monte Carlo dropout",
-                        "reasoning": "Uncertainty estimation",
-                    },
-                ]
-            },
-            "NICE_TO_HAVE": {"inference_strategies": []},
+            "MUST_HAVE": [
+                {
+                    "strategy": "Test-time augmentation",
+                    "reasoning": "Improve robustness",
+                },
+                {
+                    "strategy": "Threshold tuning",
+                    "reasoning": "Optimize for metric",
+                },
+                {
+                    "strategy": "Fold averaging",
+                    "reasoning": "Reduce variance",
+                },
+                {
+                    "strategy": "Monte Carlo dropout",
+                    "reasoning": "Uncertainty estimation",
+                },
+            ],
+            "NICE_TO_HAVE": [],
         },
     }
 
@@ -150,8 +148,8 @@ def test_empty_preprocessing_and_inference():
             "NICE_TO_HAVE": {"hyperparameters": [], "architectures": []},
         },
         "inference_strategies": {
-            "MUST_HAVE": {"inference_strategies": []},
-            "NICE_TO_HAVE": {"inference_strategies": []},
+            "MUST_HAVE": [],
+            "NICE_TO_HAVE": [],
         },
     }
     details = _format_recommendations_for_developer(recs)


### PR DESCRIPTION
## Summary

- Remove `InferenceStrategySection` wrapper — `InferenceStrategyRecommendations.MUST_HAVE` and `.NICE_TO_HAVE` are now `list[InferenceStrategyItem]` directly, eliminating the redundant `["inference_strategies"]["NICE_TO_HAVE"]["inference_strategies"]` nesting that caused `KeyError` crashes
- Fix bug in `_format_later_recommendations` where `later_section` (hyperparameters) was used instead of `inf_section` (inference) on line 307
- Rename ambiguous variables (`now_section`, `later_section`, `inf_section`, `now_items`, `now_loss`) to descriptive names (`hyperparams`, `inference`, `strategies`, `loss`) across both formatting functions
- Simplify `_extract_now_recommendations` and `_extract_later_recommendations` — remove manual dict reconstruction that just copied the same keys

## Test plan

- [x] All 34 tests pass
- [x] Zero references to `InferenceStrategySection` remain in codebase
