### PR TITLE
fix last-step tool call crash and bump SOTA step limit

### DIFF
--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -302,11 +302,13 @@ class ResearcherAgent:
                 )
                 logger.info("Reached final step; forcing plan output prompt")
 
+            is_last_step = step == max_steps - 1
+
             response = call_llm(
                 model=_RESEARCHER_AGENT_MODEL,
                 system_instruction=system_prompt,
                 messages=input_list,
-                function_declarations=tools if tools else [],
+                function_declarations=tools if (tools and not is_last_step) else [],
                 enable_google_search=True,
             )
 

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -241,7 +241,7 @@ def search_sota_suggestions(
     cpu_core_range: list[int] | None = None,
     gpu_identifier: str | None = None,
     file_suffix: str | None = None,
-    max_tool_steps: int = 20,
+    max_tool_steps: int = 128,
     version: int = 1,
     images: list[Path] | None = None,
     train_stats: dict | None = None,
@@ -346,15 +346,15 @@ def search_sota_suggestions(
             "enabled" if tools else "disabled",
         )
 
+        is_last_step = step_limit is not None and step == step_limit - 1
+
         response = call_llm(
             model=_DEVELOPER_TOOL_MODEL,
             system_instruction=system_prompt,
-            function_declarations=tools if tools else [],
+            function_declarations=tools if (tools and not is_last_step) else [],
             messages=input_list,
             enable_google_search=True,
-            text_format=SOTAResponse
-            if (step_limit is not None and step == step_limit - 1)
-            else None,
+            text_format=SOTAResponse if is_last_step else None,
         )
 
         # text_format is SOTAResponse on last step (returns Pydantic), None otherwise (returns Gemini response)


### PR DESCRIPTION
## Summary

- Fix crash where `text_format=SOTAResponse` was passed alongside `function_declarations` on the last step — model emitted a function call instead of JSON, `response.text` was `None`, and `model_validate_json(None)` threw `ValidationError`
- Disable `function_declarations` on the last step of SOTA and researcher loops so the model is forced to output text (matches the pattern already used by library investigator, log monitor, and developer code gen)
- Bump SOTA `max_tool_steps` from 20 to 128

## Test plan

- [x] All 34 tests pass
