### PR TITLE
swap blacklist field order to reduce over-blacklisting

### DIFF
--- a/prompts/tools_developer.py
+++ b/prompts/tools_developer.py
@@ -137,8 +137,8 @@ Make exactly THREE suggestions from different categories. Each should be high-im
     - If none: "No shared experiments yet."
 - Research and Suggestion (three numbered, one per category)
 - Previous Suggestion Review and New Suggestion:
-  - `blacklist_reasoning`: Justification for blacklisting previous suggestion
   - `blacklist`: Boolean — should previous suggestion be blacklisted?
+  - `blacklist_reasoning`: Justification for blacklisting previous suggestion
   - `suggestion_reasoning`: Why this is the best choice now
   - `suggestion`: Best next idea (or "No suggestions." if none viable)
   - `suggestion_code`: Complete Python code implementing the suggestion (or empty string)

--- a/schemas/developer.py
+++ b/schemas/developer.py
@@ -16,8 +16,8 @@ class SOTAResponse(BaseModel):
     red_flags_summary: str
     shared_experiences_summary: str
     research_summary: str
-    blacklist_reasoning: str
     blacklist: bool
+    blacklist_reasoning: str
     suggestion_reasoning: str
     suggestion: str
     suggestion_code: str


### PR DESCRIPTION
## Summary
- Swap `blacklist` and `blacklist_reasoning` field order in `SOTAResponse` schema and prompt to reduce over-blacklisting
- When `blacklist_reasoning` came first, the model would construct justification before deciding, biasing it toward `blacklist: True`
- Now the model makes the binary decision first, then explains it
