### PR TITLE
pass INSTRUCTIONS.md instructions to SOTA system prompt

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -1098,6 +1098,7 @@ class DeveloperAgent:
                 images=training_images if training_images else None,
                 train_stats=train_stats,
                 hitl_sota=_HITL_SOTA,
+                hitl_instructions=_HITL_INSTRUCTIONS,
             )
 
             # HITL: Show suggestion and let user accept or override

--- a/prompts/developer_agent.py
+++ b/prompts/developer_agent.py
@@ -72,9 +72,7 @@ def build_system(
 
     hitl_section = ""
     if hitl_instructions:
-        hitl_items = "\n".join(
-            [f"{i + 1}. {instr}" for i, instr in enumerate(hitl_instructions)]
-        )
+        hitl_items = "\n".join(hitl_instructions)
         hitl_section = f"""
 # Additional Instructions
 

--- a/prompts/researcher_agent.py
+++ b/prompts/researcher_agent.py
@@ -91,9 +91,7 @@ def build_system(
 
     hitl_section = ""
     if hitl_instructions:
-        hitl_items = "\n".join(
-            [f"{i + 1}. {instr}" for i, instr in enumerate(hitl_instructions)]
-        )
+        hitl_items = "\n".join(hitl_instructions)
         hitl_section = f"""
 # Additional Instructions
 

--- a/prompts/tools_developer.py
+++ b/prompts/tools_developer.py
@@ -73,8 +73,22 @@ def red_flags_user(
 """
 
 
-def sota_system(time_limit_minutes: int = 90) -> str:
-    return f"""You receive a Kaggle competition description, researcher plans, initial script with logs, red flags, and shared experiment results.
+def sota_system(
+    time_limit_minutes: int = 90,
+    hitl_instructions: list[str] | None = None,
+) -> str:
+    hitl_section = ""
+    if hitl_instructions:
+        hitl_items = "\n".join(hitl_instructions)
+        hitl_section = f"""
+# Additional Instructions
+
+{hitl_items}
+
+---
+"""
+
+    return f"""{hitl_section}You receive a Kaggle competition description, researcher plans, initial script with logs, red flags, and shared experiment results.
 
 ## Constraints
 - Do NOT use winning solutions from this competition.

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -246,6 +246,7 @@ def search_sota_suggestions(
     images: list[Path] | None = None,
     train_stats: dict | None = None,
     hitl_sota: bool = False,
+    hitl_instructions: list[str] | None = None,
 ) -> str:
     """Stage 2: Use web search and tools to generate SOTA suggestions based on red flags."""
     logger.info(
@@ -314,7 +315,10 @@ def search_sota_suggestions(
 
     time_limit_minutes = int(_BASELINE_CODE_TIMEOUT / 60)
 
-    system_prompt = prompt_sota_system(time_limit_minutes=time_limit_minutes)
+    system_prompt = prompt_sota_system(
+        time_limit_minutes=time_limit_minutes,
+        hitl_instructions=hitl_instructions,
+    )
 
     user_prompt = prompt_sota_user(
         description=description,


### PR DESCRIPTION
## Summary

- Pass `INSTRUCTIONS.md` developer instructions to the SOTA suggestions tool call, which previously only received them in the Developer agent
- Remove redundant {i + 1}. numbering from hitl_instructions formatting across all prompts (developer, researcher, SOTA)