### PR TITLE
remove validated findings hint for suggestions agent

### DIFF
--- a/prompts/tools_developer.py
+++ b/prompts/tools_developer.py
@@ -109,21 +109,13 @@ Each entry shows: which model tried the suggestion, what it was, score change (b
 3. **Remove detrimental components**: If component X worsened performance across models and it's in your code, remove it.
 4. **Semantic deduplication**: Don't repeat identical suggestions.
 
-**Mandatory: Plan's Validated Findings**
-- Review `<plan>` "Validated Findings" for "High Impact" A/B tested strategies
-- Compare against `<initial script>` to find which are NOT yet implemented
-- List missing findings in "Summary of Plan" section
-- Prioritize these in your recommendations
-
 ## Making Suggestions
 
 **Before generating suggestions:**
 1. Review `<plan>` "Data Understanding & Profiling" for data/schema context
 2. Review `<initial script>` for existing techniques
-3. Review `<plan>` "Validated Findings" for A/B tested successes
-4. Prioritize validated findings not yet in code
-5. Be SPECIFIC — reference concrete columns, techniques, parameters
-6. Do NOT suggest what is already present
+3. Be SPECIFIC — reference concrete columns, techniques, parameters
+4. Do NOT suggest what is already present
 
 **Categories** (select 3 most relevant):
 1. Data/Feature Engineering/Preprocessing
@@ -144,8 +136,6 @@ Make exactly THREE suggestions from different categories. Each should be high-im
 ## Output Format
 - Checklist (3-7 bullets)
 - Summary of Plan
-    - Items from "Validated Findings (High Impact)" not in code
-    - If none missing: "No high-impact validated findings missing."
 - Summary of Red Flags
 - Summary of Shared Experiments
     - If none: "No shared experiments yet."

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -286,30 +286,9 @@ def search_sota_suggestions(
             else "No shared suggestions yet."
         )
 
-    # On even attempts, strip "Validated Findings" section from plan to focus on other recommendations
-    modified_plan_content = plan_content
-    if attempt_number % 2 == 0 and plan_content:
-        validated_start = "# Validated Findings (A/B Tested)"
-        risks_start = "# Risks & Mitigations"
-
-        start_idx = plan_content.find(validated_start)
-        end_idx = plan_content.find(risks_start)
-
-        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-            logger.info(
-                "Attempt #%d (even): Stripping 'Validated Findings' section (%d chars)",
-                attempt_number,
-                end_idx - start_idx,
-            )
-            modified_plan_content = plan_content[:start_idx] + plan_content[end_idx:]
-        else:
-            logger.warning(
-                "Could not find both section headers to strip Validated Findings"
-            )
-
     plans_section = ""
-    if modified_plan_content:
-        plans_section += f"\n<plan>\n{modified_plan_content}\n</plan>\n"
+    if plan_content:
+        plans_section += f"\n<plan>\n{plan_content}\n</plan>\n"
     if later_recommendations:
         plans_section += f"\n<suggestions>\n{later_recommendations}\n</suggestions>\n"
 


### PR DESCRIPTION
## Summary

- Always pass the full plan to SOTA — remove the even-attempt stripping of the "Validated Findings" section
- Remove all "Validated Findings" references from the SOTA system prompt