### PR TITLE
Add pre-execution lint guardrail before running generated code

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -53,6 +53,7 @@ _DEVELOPER_CFG = _CONFIG["developer"]
 _ENABLE_LOGGING_GUARD = bool(_GUARDRAIL_CFG["logging_basicconfig_order"])
 _ENABLE_LEAKAGE_GUARD = bool(_GUARDRAIL_CFG["leakage_review"])
 _ENABLE_CODE_SAFETY = bool(_GUARDRAIL_CFG["enable_code_safety"])
+_ENABLE_LINT_GUARD = bool(_GUARDRAIL_CFG.get("pre_execution_lint", True))
 
 _USE_VALIDATION_SCORE = bool(_RUNTIME_CFG["use_validation_score"])
 
@@ -1611,6 +1612,7 @@ Fix the error. Write logs to {next_log_path} and save all required artifacts to 
                 enable_logging_guard=_ENABLE_LOGGING_GUARD,
                 enable_leakage_guard=_ENABLE_LEAKAGE_GUARD,
                 enable_code_safety=_ENABLE_CODE_SAFETY,
+                enable_lint_guard=_ENABLE_LINT_GUARD,
             )
 
             self.logger.info(

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,7 @@ guardrails:
   logging_basicconfig_order: true
   leakage_review: true
   enable_code_safety: true
+  pre_execution_lint: true
 tracking:
   wandb:
     entity: bogoconic1 # replace with your W&B entity

--- a/guardrails/linting.py
+++ b/guardrails/linting.py
@@ -1,0 +1,50 @@
+"""Static lint guardrail checks for generated Python code."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def check_python_lint(code: str, filename: str = "generated_train.py") -> dict:
+    """Run a fast lint check to catch undefined/unassigned variables before execution.
+
+    Uses pyflakes when available; if pyflakes is unavailable, the check is skipped.
+    """
+    try:
+        from pyflakes.api import check as pyflakes_check
+        from pyflakes.reporter import Reporter
+    except Exception:
+        logger.warning("pyflakes is not available; skipping lint guardrail")
+        return {
+            "decision": "proceed",
+            "status": "skipped",
+            "reason": "pyflakes not installed",
+            "errors": [],
+        }
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    reporter = Reporter(stdout, stderr)
+
+    issue_count = pyflakes_check(code, filename=filename, reporter=reporter)
+    output = "\n".join(x for x in (stdout.getvalue(), stderr.getvalue()) if x).strip()
+
+    if issue_count > 0:
+        errors = [line.strip() for line in output.splitlines() if line.strip()]
+        logger.warning("Lint guardrail blocked execution: %d issue(s)", issue_count)
+        return {
+            "decision": "block",
+            "status": "fail",
+            "reason": f"Detected {issue_count} lint issue(s)",
+            "errors": errors,
+        }
+
+    return {
+        "decision": "proceed",
+        "status": "pass",
+        "reason": "No lint issues detected",
+        "errors": [],
+    }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,3 +12,4 @@ google-genai
 PyYAML
 requests
 firecrawl-py
+pyflakes

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ catboost
 pyyaml
 exa-py
 firecrawl-py
+pyflakes
 sentence-transformers
 python-dotenv
 kaggle

--- a/tests/test_guardrails_lint.py
+++ b/tests/test_guardrails_lint.py
@@ -1,0 +1,38 @@
+import pytest
+
+pytest.importorskip("pyflakes")
+
+from guardrails.linting import check_python_lint
+from utils.guardrails import evaluate_guardrails, build_block_summary
+
+
+def test_check_python_lint_passes_for_valid_code():
+    result = check_python_lint("x = 1\nprint(x)\n")
+    assert result["decision"] == "proceed"
+
+
+def test_check_python_lint_blocks_undefined_name():
+    result = check_python_lint("print(missing_name)\n")
+    assert result["decision"] == "block"
+    assert any("missing_name" in err for err in result["errors"])
+
+
+def test_evaluate_guardrails_blocks_on_lint_issue(monkeypatch):
+    monkeypatch.setattr(
+        "utils.guardrails.check_code_safety",
+        lambda _code: {"decision": "proceed", "reason": "ok"},
+    )
+
+    report = evaluate_guardrails(
+        code_text="print(missing_name)\n",
+        enable_logging_guard=False,
+        enable_leakage_guard=False,
+        enable_code_safety=True,
+        enable_lint_guard=True,
+    )
+
+    assert report["decision"] == "block"
+    assert report["lint_check"]["decision"] == "block"
+
+    summary = build_block_summary(report)
+    assert "pre-execution lint check" in summary

--- a/utils/guardrails.py
+++ b/utils/guardrails.py
@@ -2,6 +2,7 @@ import logging
 
 from guardrails.developer import check_logging_basicconfig_order, llm_leakage_review
 from guardrails.code_safety import check_code_safety, format_safety_feedback
+from guardrails.linting import check_python_lint
 from schemas.guardrails import LeakageReviewResponse
 
 
@@ -14,12 +15,14 @@ def evaluate_guardrails(
     enable_logging_guard: bool,
     enable_leakage_guard: bool,
     enable_code_safety: bool,
+    enable_lint_guard: bool,
 ) -> dict:
     """Run all configured guardrails and return a unified report with decision."""
     guard_report: dict = {
         "logging_check": {},
         "leakage_check": {},
         "safety_check": {},
+        "lint_check": {},
         "decision": "proceed",
     }
 
@@ -44,6 +47,13 @@ def evaluate_guardrails(
         if safety_check["decision"] == "block":
             guard_report["decision"] = "block"
     guard_report["safety_check"] = safety_check
+
+    lint_check: dict = {"decision": "proceed", "status": "skipped", "reason": "disabled in config", "errors": []}
+    if enable_lint_guard:
+        lint_check = check_python_lint(code_text)
+        if lint_check["decision"] == "block":
+            guard_report["decision"] = "block"
+    guard_report["lint_check"] = lint_check
 
     return guard_report
 
@@ -71,6 +81,14 @@ def build_block_summary(guard_report: dict) -> str:
                 lines.append(
                     f"{idx}. rule_id={f.rule_id}\n   - snippet: {f.snippet}\n   - rationale: {f.rationale}\n   - suggestion: {f.suggestion}"
                 )
+
+    lint_check = guard_report["lint_check"]
+    if lint_check["decision"] == "block":
+        if lines:
+            lines.append("\n---\n")
+        lines.append("Code BLOCKED by pre-execution lint check:")
+        for err in lint_check.get("errors", []):
+            lines.append(f"- {err}")
 
     log_check = guard_report["logging_check"]
     if log_check["status"] == "fail":


### PR DESCRIPTION
## Summary
- add a new pre-execution lint guardrail (guardrails/linting.py) that runs pyflakes against generated Python
- wire lint guardrail into evaluate_guardrails() and block execution when lint errors are found (including undefined / referenced-before-assignment names)
- surface lint failures in build_block_summary() so the model can regenerate code before training
- add guardrails.pre_execution_lint config toggle (default true) and pass it from DeveloperAgent
- add pyflakes to requirements and add focused guardrail lint tests

## Test Notes
- python3 -m pytest -q tests/test_guardrails_lint.py *(cannot run in this environment because pytest is not installed)*
- manual smoke check run: python3 - <<'PY' ... check_python_lint('print(missing_name)') ...
  - current sandbox reports pyflakes not installed and skips lint, expected in this environment
  - in project envs with dependencies installed, lint check blocks on undefined names

Closes #179
