### PR TITLE
refactor: migrate observability from Weave to Langfuse

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -9,7 +9,7 @@ import json
 
 from dotenv import load_dotenv
 from project_config import get_config, get_config_value, get_instructions
-import weave
+from utils.observability import op
 import wandb
 
 from tools.developer import (
@@ -306,7 +306,7 @@ class DeveloperAgent:
             else "No NICE_TO_HAVE recommendations available."
         )
 
-    @weave.op()
+    @op()
     def _generate_code(
         self, instructions: str, messages: list[dict[str, str]]
     ) -> tuple[list[dict], str, int | None]:
@@ -1452,7 +1452,7 @@ Fix the error. Write logs to {next_log_path} and save all required artifacts to 
 
         return sota_suggestions_call_id, False
 
-    @weave.op()
+    @op()
     def run(
         self, max_time_seconds: int = 6 * 3600
     ) -> tuple[float, str | None, list[str], list[str]]:

--- a/agents/model_recommender.py
+++ b/agents/model_recommender.py
@@ -5,8 +5,8 @@ import logging
 from pathlib import Path
 
 from dotenv import load_dotenv
-import weave
-from weave.trace.util import ThreadPoolExecutor
+from utils.observability import op
+from concurrent.futures import ThreadPoolExecutor
 
 from project_config import get_config, get_instructions
 from tools.helpers import call_llm
@@ -152,7 +152,7 @@ class ModelRecommenderAgent:
             enable_google_search=_ENABLE_WEB_SEARCH,
         )
 
-    @weave.op()
+    @op()
     def _recommend_preprocessing(self, model_name: str) -> dict:
         """Get preprocessing recommendations for a model."""
         user_prompt = build_user_prompt(
@@ -178,7 +178,7 @@ class ModelRecommenderAgent:
         )
         return result
 
-    @weave.op()
+    @op()
     def _recommend_loss_function(self, model_name: str) -> dict:
         """Get loss function recommendation for a model."""
         user_prompt = build_user_prompt(
@@ -204,7 +204,7 @@ class ModelRecommenderAgent:
         )
         return result
 
-    @weave.op()
+    @op()
     def _recommend_hyperparameters(self, model_name: str) -> dict:
         """Get hyperparameter and architecture recommendations for a model."""
         user_prompt = build_user_prompt(
@@ -230,7 +230,7 @@ class ModelRecommenderAgent:
         )
         return result
 
-    @weave.op()
+    @op()
     def _recommend_inference(self, model_name: str) -> dict:
         """Get inference strategy recommendations for a model."""
         user_prompt = build_user_prompt(
@@ -256,7 +256,7 @@ class ModelRecommenderAgent:
         )
         return result
 
-    @weave.op()
+    @op()
     def _recommend_for_model(self, model_name: str) -> dict:
         """Generate all recommendations for a single model.
 
@@ -278,7 +278,7 @@ class ModelRecommenderAgent:
         logger.info("[%s] All recommendations completed", model_name)
         return recommendations
 
-    @weave.op()
+    @op()
     def select_models(self) -> list[str]:
         """Three-stage model selection process:
         Stage 1: Select 16 candidate models using LLM with web search
@@ -344,7 +344,7 @@ class ModelRecommenderAgent:
         )
         return final_models
 
-    @weave.op()
+    @op()
     def _fetch_paper_summaries(self, model_names: list[str]) -> dict[str, str]:
         """Fetch paper summaries for all models in parallel using Gemini.
 
@@ -394,7 +394,7 @@ class ModelRecommenderAgent:
 
         return summaries
 
-    @weave.op()
+    @op()
     def _refine_model_selection(
         self, candidate_models: list[str], summaries: dict[str, str]
     ) -> list[str]:
@@ -447,7 +447,7 @@ class ModelRecommenderAgent:
 
         return final_models
 
-    @weave.op()
+    @op()
     def run(
         self, model_list: list[str] | None = None, use_dynamic_selection: bool = False
     ) -> dict:

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -16,8 +16,8 @@ from utils.checkpoint import (
     create_db as _create_checkpoint_db,
     delete_checkpoints_after,
 )
-from weave.trace.util import ThreadPoolExecutor
-import weave
+from concurrent.futures import ThreadPoolExecutor
+from utils.observability import op
 
 
 _CONFIG = get_config()
@@ -246,7 +246,7 @@ def _ensure_conda_environments(num_workers: int) -> None:
     print()
 
 
-@weave.op()
+@op()
 def _run_developer_baseline(
     slug: str,
     iteration_suffix: str,
@@ -502,7 +502,7 @@ class Orchestrator:
         conn.close()
         print(f"Rollback to version {target} complete")
 
-    @weave.op()
+    @op()
     def run(self) -> tuple[bool, str]:
         # Phase 1: Starter Agent - Get task type and summary
         starter_suggestion_path = self.outputs_dir / "starter_suggestions.json"

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -16,7 +16,7 @@ from prompts.researcher_agent import (
 )
 from tools.helpers import call_llm
 from google.genai import types
-import weave
+from utils.observability import op
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +277,7 @@ class ResearcherAgent:
                 "is_error": False,
             }
 
-    @weave.op()
+    @op()
     def build_plan(self, max_steps: int | None = None) -> str:
         system_prompt = self._compose_system()
         starter_suggestions = self._read_starter_suggestions()

--- a/agents/starter.py
+++ b/agents/starter.py
@@ -12,7 +12,7 @@ from prompts.starter_agent import (
     build_user as prompt_build_user,
 )
 from schemas.starter import StarterSuggestions
-import weave
+from utils.observability import op
 
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ class StarterAgent:
             logger.addHandler(fh)
         logger.setLevel(logging.DEBUG)
 
-    @weave.op()
+    @op()
     def run(self):
         """Run the starter prompt and persist outputs; return parsed suggestions."""
         with open(self.base_dir / "description.md", "r") as f:

--- a/launch_agent.py
+++ b/launch_agent.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 
 from agents.orchestrator import Orchestrator
 from project_config import get_config_value
-import weave
+from utils import observability
 import wandb
 
 
@@ -42,7 +42,7 @@ def _resolve_wandb_target(
 
 
 def _init_tracking(args: argparse.Namespace) -> None:
-    """Initialise wandb and weave using the best available configuration."""
+    """Initialise wandb and Langfuse using the best available configuration."""
 
     entity, project = _resolve_wandb_target(args.wandb_entity, args.wandb_project)
     run_name = getattr(args, "wandb_run_name", None) or f"{args.iteration}-{args.slug}"
@@ -58,7 +58,7 @@ def _init_tracking(args: argparse.Namespace) -> None:
 
     wandb.init(**wandb_kwargs)
     weave_project = f"{entity}/{project}" if entity else project
-    weave.init(project_name=weave_project)
+    observability.init(project_name=weave_project)
 
 
 def main():
@@ -88,7 +88,7 @@ def main():
 
     # Gracefully close tracking backends to avoid hanging background threads
     try:
-        weave.finish()
+        observability.finish()
     except Exception:
         pass
     try:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ pytest
 pytest-cov
 pydantic
 python-dotenv
-weave
+langfuse
 wandb
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ bitsandbytes
 tf-keras
 sentencepiece
 wandb
-weave
+langfuse
 timm
 datasets
 tensorboard

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -32,7 +32,7 @@ from prompts.tools_developer import (
     log_monitor_user as prompt_log_monitor_user,
 )
 from schemas.developer import StackTraceSolution, SOTAResponse, LogMonitorVerdict, RedFlagsResponse
-import weave
+from utils.observability import op
 
 load_dotenv()
 
@@ -72,7 +72,7 @@ def _build_resource_header(
     return "\n".join(lines) + "\n"
 
 
-@weave.op()
+@op()
 def web_search_stack_trace(query: str) -> str:
     """Research how to fix a bug based on the stack trace and error message."""
     logger.info("Dispatching web search for stack trace remediation guidance.")
@@ -160,7 +160,7 @@ def _ingest_images_for_llm(images: list[Path]) -> list[dict] | None:
     return [{"role": "user", "parts": image_content}]
 
 
-@weave.op()
+@op()
 def search_red_flags(
     description: str,
     context: str,
@@ -224,7 +224,7 @@ def _inject_user_guidance(input_list, guidance):
     )
 
 
-@weave.op()
+@op()
 def search_sota_suggestions(
     description: str,
     context: str,
@@ -590,7 +590,7 @@ class ExecutionJob:
         return self.elapsed() > self._timeout_seconds
 
 
-@weave.op()
+@op()
 def execute_code(
     filepath: str, timeout_seconds: int | None = None, conda_env: str | None = None
 ) -> "ExecutionJob":

--- a/tools/generate_paper_summary.py
+++ b/tools/generate_paper_summary.py
@@ -1,5 +1,5 @@
 from dotenv import load_dotenv
-import weave
+from utils.observability import op
 
 from project_config import get_config
 from tools.helpers import call_llm
@@ -56,7 +56,7 @@ Second, you need to **access the paper's content** using this ID (e.g., by retri
 - Experiments/Results: Focus on quantitative data, benchmark scores, comparative gains, and key ablation findings.
 - Purpose: it must contain a brief, descriptive sentence explaining the section's function in the paper."""
 
-    @weave.op()
+    @op()
     def generate_summary(self, model_name: str, user_prompt: str | None = None) -> str:
         if user_prompt:
             prompt = user_prompt.format(model_name=model_name)

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -6,7 +6,7 @@ from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 import httpx
-import weave
+from utils.observability import op
 
 from project_config import get_config
 
@@ -149,7 +149,7 @@ def _build_directory_listing(root: str, num_files: int | None = None) -> str:
     return "\n".join(lines)
 
 
-@weave.op()
+@op()
 def call_llm(
     model: str,
     system_instruction: str,

--- a/tools/researcher.py
+++ b/tools/researcher.py
@@ -4,7 +4,7 @@ import re
 
 from dotenv import load_dotenv
 from firecrawl import Firecrawl
-import weave
+from utils.observability import op
 from tools.generate_paper_summary import PaperSummaryClient
 
 load_dotenv()
@@ -19,7 +19,7 @@ for _noisy in ("httpcore", "httpx", "urllib3"):
 logger = logging.getLogger(__name__)
 
 
-@weave.op()
+@op()
 def read_research_paper(arxiv_link: str) -> str:
     """Read and summarize a research paper from arxiv.
 
@@ -45,7 +45,7 @@ def read_research_paper(arxiv_link: str) -> str:
     return summary
 
 
-@weave.op()
+@op()
 def scrape_web_page(url: str) -> str:
     """Scrape a web page and return LLM-ready markdown content.
 

--- a/utils/observability.py
+++ b/utils/observability.py
@@ -1,0 +1,86 @@
+"""Observability helpers backed by Langfuse.
+
+Provides a tiny compatibility layer so modules can use:
+- @op() decorator for traced functions
+- init(project_name=...) during startup
+- finish() during shutdown
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from langfuse import Langfuse
+    from langfuse.decorators import observe
+except Exception:  # pragma: no cover - graceful fallback if optional dep missing
+    Langfuse = None
+    observe = None
+
+
+_langfuse_client: Optional[Any] = None
+
+
+def init(project_name: Optional[str] = None) -> None:
+    """Initialise Langfuse client.
+
+    `project_name` is accepted for backward compatibility with previous setup.
+    """
+
+    global _langfuse_client
+
+    if Langfuse is None:
+        logger.warning("Langfuse is not available; observability disabled.")
+        return
+
+    if _langfuse_client is not None:
+        return
+
+    try:
+        # Langfuse config is read from env vars; keep project_name as a no-op arg.
+        _langfuse_client = Langfuse()
+        logger.info("Langfuse observability initialized")
+    except Exception:
+        logger.exception("Failed to initialize Langfuse; observability disabled.")
+        _langfuse_client = None
+
+
+def finish() -> None:
+    """Flush and shutdown Langfuse client."""
+
+    global _langfuse_client
+
+    if _langfuse_client is None:
+        return
+
+    try:
+        _langfuse_client.flush()
+    except Exception:
+        logger.exception("Failed to flush Langfuse traces")
+    finally:
+        _langfuse_client = None
+
+
+def op(*args: Any, **kwargs: Any):
+    """Decorator compatible with `@weave.op()` usage."""
+
+    if observe is None:
+        # No-op fallback preserving call signature for both @op and @op(...)
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return args[0]
+
+        def _decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            @wraps(func)
+            def _wrapped(*f_args: Any, **f_kwargs: Any) -> Any:
+                return func(*f_args, **f_kwargs)
+
+            return _wrapped
+
+        return _decorator
+
+    # Map to Langfuse's observe decorator.
+    return observe(*args, **kwargs)


### PR DESCRIPTION
## Summary
- replace Weave-based tracing with a Langfuse-backed observability wrapper (`utils/observability.py`)
- swap all `@weave.op()` decorators to `@op()` from the new wrapper across agents/tools
- replace Weave `ThreadPoolExecutor` imports with Python stdlib `concurrent.futures.ThreadPoolExecutor`
- update startup/shutdown tracking hooks in `launch_agent.py` to initialize/flush Langfuse
- replace `weave` dependency with `langfuse` in runtime and test requirements

Closes #173

## Test Notes
- `python3 -m compileall launch_agent.py agents tools utils`
- `pytest` is not available in this environment (`command not found`)
- full runtime smoke test is blocked here because optional deps (e.g. `python-dotenv`) are not installed in this sandbox