### PR TITLE
chore: add .env.example with required API/config variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Qgentic-AI environment variables
+# Copy this file to .env and fill in required values.
+#
+#   cp .env.example .env
+#
+# Notes:
+# - Kaggle access can be configured either via KAGGLE_USERNAME/KAGGLE_KEY
+#   or by placing kaggle.json in the project root.
+# - Weights & Biases defaults can also be set in config.yaml under tracking.wandb.
+
+# --- Required API keys ---
+# Used by google-genai (Gemini models)
+GOOGLE_API_KEY=
+
+# Used by tools/researcher.py (Firecrawl web extraction)
+FIRECRAWL_API_KEY=
+
+# --- Optional Kaggle credentials (alternative to kaggle.json) ---
+KAGGLE_USERNAME=
+KAGGLE_KEY=
+
+# --- Optional Weights & Biases overrides ---
+# If unset, launch_agent.py falls back to config.yaml values.
+WANDB_ENTITY=
+WANDB_PROJECT=


### PR DESCRIPTION
## Summary
- add `.env.example` to document environment variables needed by the current codebase
- include required keys for Gemini (`GOOGLE_API_KEY`) and Firecrawl (`FIRECRAWL_API_KEY`)
- include optional Kaggle (`KAGGLE_USERNAME`, `KAGGLE_KEY`) and W&B (`WANDB_ENTITY`, `WANDB_PROJECT`) overrides with inline notes

Closes #159

## Test Notes
- verified `.env.example` is present at repo root
- compared env vars referenced in code (`os.environ` / `os.getenv`) against the example to ensure user-provided API/config vars are covered
