### PR TITLE
fix: limit checkpoint retention to prevent DB bloat

### DIFF
--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,46 @@
+from utils import checkpoint as checkpoint_utils
+
+
+def _sample_state(version: int) -> dict:
+    return {
+        "best_score": float(version),
+        "best_version": version,
+        "best_code_file": f"v{version}.py",
+        "version_scores": {str(version): float(version)},
+        "successful_versions": [version],
+        "blacklisted_versions": [],
+        "blacklisted_ideas": [],
+        "successful_ideas": [],
+        "global_suggestions": [],
+        "input_list": [f"input-{version}"],
+        "last_input_tokens": version,
+        "last_suggestion": f"suggestion-{version}",
+        "sota_suggestions_call_id": version,
+    }
+
+
+def test_save_checkpoint_prunes_old_versions(monkeypatch, tmp_path):
+    monkeypatch.setattr(checkpoint_utils, "_CHECKPOINT_RETENTION", 3)
+
+    db_path = tmp_path / "checkpoints.db"
+    conn = checkpoint_utils.create_db(db_path)
+
+    for version in range(1, 6):
+        checkpoint_utils.save_checkpoint(
+            conn,
+            slug="s",
+            iteration="1",
+            model_name="m",
+            version=version,
+            state=_sample_state(version),
+        )
+
+    versions = [
+        row[0]
+        for row in conn.execute(
+            "SELECT version FROM checkpoints WHERE slug = ? AND iteration = ? ORDER BY version",
+            ("s", "1"),
+        ).fetchall()
+    ]
+
+    assert versions == [3, 4, 5]

--- a/utils/checkpoint.py
+++ b/utils/checkpoint.py
@@ -1,6 +1,7 @@
 import sqlite3
 import json
 import time
+import os
 from pathlib import Path
 
 _JSONB_FIELDS = [
@@ -41,6 +42,10 @@ _SELECT_COLS = ", ".join(
 
 # Resolve DB path relative to project root (Qgentic-AI/checkpoints.db)
 _DB_PATH = Path(__file__).resolve().parent.parent / "checkpoints.db"
+
+# Keep only the most recent N checkpoints for a run to avoid unbounded DB growth.
+# Override via env var QGENTIC_CHECKPOINT_RETENTION.
+_CHECKPOINT_RETENTION = int(os.getenv("QGENTIC_CHECKPOINT_RETENTION", "50"))
 
 
 def create_db(db_path: str | Path = _DB_PATH) -> sqlite3.Connection:
@@ -114,7 +119,34 @@ def save_checkpoint(
             time.time(),
         ),
     )
+    _prune_old_checkpoints(conn, slug, iteration)
     conn.commit()
+
+
+def _prune_old_checkpoints(
+    conn: sqlite3.Connection, slug: str, iteration: str, keep_last: int | None = None
+) -> None:
+    """Keep only the latest checkpoints for a run to limit disk usage."""
+    if keep_last is None:
+        keep_last = _CHECKPOINT_RETENTION
+    if keep_last <= 0:
+        return
+
+    conn.execute(
+        """
+        DELETE FROM checkpoints
+        WHERE slug = ?
+          AND iteration = ?
+          AND version NOT IN (
+              SELECT version
+              FROM checkpoints
+              WHERE slug = ? AND iteration = ?
+              ORDER BY version DESC
+              LIMIT ?
+          )
+    """,
+        (slug, iteration, slug, iteration, keep_last),
+    )
 
 
 def load_checkpoint(


### PR DESCRIPTION
## Summary
- keep checkpoint history bounded per `(slug, iteration)` by pruning older rows after each save
- default retention is 50 checkpoints and is configurable via `QGENTIC_CHECKPOINT_RETENTION`
- add a focused unit test covering pruning behavior

## Test Notes
- manual targeted verification via Python snippet
  - created 5 checkpoints with retention forced to 3
  - confirmed only versions `[3, 4, 5]` remain

Closes #164
