### PR TITLE
add standalone goal mode developer agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ cache/
 task/
 catboost_info/
 wandb/
+goal_runs/
+GOAL.md
 # C extensions
 *.so
 

--- a/agents/developer.py
+++ b/agents/developer.py
@@ -13,8 +13,7 @@ import weave
 import wandb
 
 from tools.developer import (
-    execute_code,
-    monitor_logs,
+    execute_with_monitor,
     search_red_flags,
     search_sota_suggestions,
     _LOG_MONITOR_INTERVAL,
@@ -474,63 +473,18 @@ class DeveloperAgent:
     def _execute_code(self, code_path: Path, version: int) -> str:
         """Execute code with LLM-based log monitoring.
 
-        Launches the script non-blocking, then polls with monitor_logs() every
-        _LOG_MONITOR_INTERVAL seconds. The monitor LLM inspects recent output
-        and can run bash commands (nvidia-smi, ps, etc.) to check system state.
-        If the monitor returns "kill", the process group is terminated immediately.
-
-        Args:
-            code_path: Path to the code file to execute (e.g., outputs/16_2/1/train.py)
-            version: Version number for logging
-
-        Returns:
-            Execution output string
+        Thin wrapper around ``tools.developer.execute_with_monitor`` so the
+        same launch/monitor loop is shared between the existing developer
+        flow and the standalone goal-mode agent.
         """
-        timeout_seconds = _BASELINE_CODE_TIMEOUT
-
-        job = execute_code(
-            str(code_path),
-            timeout_seconds=timeout_seconds,
+        output = execute_with_monitor(
+            code_path,
+            timeout_seconds=_BASELINE_CODE_TIMEOUT,
+            log_monitor_interval=_LOG_MONITOR_INTERVAL,
+            logger=self.logger,
             conda_env=self.conda_env,
         )
-        self.logger.info(
-            "Launched execution for v%s (pid=%d, timeout=%ds)",
-            version,
-            job.pid,
-            timeout_seconds,
-        )
-
-        while not job.done():
-            if job.check_timeout():
-                self.logger.warning("Hard timeout reached for v%s", version)
-                return job.kill("Hard timeout exceeded")
-
-            try:
-                verdict = monitor_logs(
-                    log_output=job.recent_output(),
-                    seconds_since_last_output=job.idle_time(),
-                    total_elapsed_seconds=job.elapsed(),
-                    pid=job.pid,
-                )
-                self.logger.info(
-                    "Monitor verdict for v%s: %s (%s)",
-                    version,
-                    verdict.action,
-                    verdict.reasoning,
-                )
-                if verdict.action == "kill":
-                    return job.kill(verdict.reasoning)
-            except Exception:
-                self.logger.exception(
-                    "Monitor call failed for v%s — continuing execution", version
-                )
-
-            time.sleep(_LOG_MONITOR_INTERVAL)
-
-        output = job.result()
-        self.logger.info("Execution output captured for version v%s", version)
-        self.logger.debug("Execution output: %s", output)
-
+        self.logger.debug("Execution output for v%s: %s", version, output)
         return output
 
     def _format_suggestion_entry(

--- a/agents/goal_developer.py
+++ b/agents/goal_developer.py
@@ -1,0 +1,217 @@
+"""Standalone goal-mode developer agent.
+
+Reads a free-form goal description, iterates a generate-execute-review loop
+until the reviewer reports `done` or the limits are exhausted. Independent
+of the existing developer flow at the orchestration level — but reuses the
+shared low-level helpers (`call_llm`, `execute_with_monitor`,
+`evaluate_guardrails`, `extract_python_code`).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import weave
+
+from project_config import get_config
+from prompts.goal_developer import (
+    codegen_system,
+    initial_codegen_user,
+    next_codegen_user,
+    review_system,
+    review_user,
+)
+from schemas.goal_developer import GoalReview
+from tools.developer import execute_with_monitor
+from tools.helpers import call_llm
+from utils.code_utils import extract_python_code
+from utils.guardrails import build_block_summary, evaluate_guardrails
+from utils.llm_utils import append_message
+
+
+logger = logging.getLogger(__name__)
+
+
+_CONFIG = get_config()
+_LLM_CFG = _CONFIG["llm"]
+_RUNTIME_CFG = _CONFIG["runtime"]
+_GUARDRAIL_CFG = _CONFIG["guardrails"]
+
+_DEVELOPER_MODEL = _LLM_CFG["developer_model"]
+_DEVELOPER_TOOL_MODEL = _LLM_CFG["developer_tool_model"]
+_BASELINE_CODE_TIMEOUT = _RUNTIME_CFG["baseline_code_timeout"]
+_LOG_MONITOR_INTERVAL = _RUNTIME_CFG["log_monitor_interval"]
+
+_ENABLE_LOGGING_GUARD = bool(_GUARDRAIL_CFG["logging_basicconfig_order"])
+_ENABLE_LEAKAGE_GUARD = bool(_GUARDRAIL_CFG["leakage_review"])
+_ENABLE_CODE_SAFETY = bool(_GUARDRAIL_CFG["enable_code_safety"])
+
+
+@dataclass
+class HistoryEntry:
+    """One iteration of the goal-mode loop, persisted to history.json."""
+
+    version: int
+    code: str
+    review: GoalReview | None  # None when guardrails blocked the version pre-execution
+
+    def to_dict(self) -> dict:
+        return {
+            "version": self.version,
+            "code": self.code,
+            "review": self.review.model_dump() if self.review is not None else None,
+        }
+
+
+@weave.op()
+def run_goal_mode(
+    goal_text: str,
+    run_dir: Path,
+    max_versions: int = 50,
+    max_time_seconds: int = 6 * 3600,
+) -> list[HistoryEntry]:
+    """Run the goal-mode loop until the reviewer reports done or limits hit.
+
+    Writes per-version artifacts under ``run_dir/v{N}/`` and a summary
+    ``history.json`` under ``run_dir/``. Returns the full history.
+    """
+    run_dir.mkdir(parents=True, exist_ok=True)
+    history: list[HistoryEntry] = []
+
+    v1_dir = run_dir / "v1"
+    input_list: list[dict] = [
+        append_message("user", initial_codegen_user(goal_text, v1_dir))
+    ]
+
+    deadline = time.monotonic() + max_time_seconds
+
+    for version in range(1, max_versions + 1):
+        if time.monotonic() >= deadline:
+            logger.info("max_time_seconds reached before v%s", version)
+            break
+
+        version_dir = run_dir / f"v{version}"
+        version_dir.mkdir(parents=True, exist_ok=True)
+        next_dir = run_dir / f"v{version + 1}"
+
+        # 1. Generate code
+        try:
+            code = _generate_code(input_list)
+        except Exception:
+            logger.exception("Code generation failed at v%s — aborting loop", version)
+            break
+
+        # Echo the canonical code block back into the thread as the assistant turn.
+        input_list.append(append_message("assistant", f"```python\n{code}\n```"))
+
+        # 2. Persist train.py before any further checks
+        train_py = version_dir / "train.py"
+        train_py.write_text(code)
+        logger.info("v%s: wrote %s", version, train_py)
+
+        # 3. Pre-execution guardrails (logging order, leakage, code safety)
+        guard_report = evaluate_guardrails(
+            code_text=code,
+            enable_logging_guard=_ENABLE_LOGGING_GUARD,
+            enable_leakage_guard=_ENABLE_LEAKAGE_GUARD,
+            enable_code_safety=_ENABLE_CODE_SAFETY,
+        )
+        logger.info("v%s: guardrail decision = %s", version, guard_report["decision"])
+
+        if guard_report["decision"] == "block":
+            block_summary = build_block_summary(guard_report)
+            (version_dir / "guardrails_block.txt").write_text(block_summary)
+            history.append(HistoryEntry(version=version, code=code, review=None))
+            input_list.append(
+                append_message(
+                    "user",
+                    f"""<guardrails_block>
+{block_summary}
+</guardrails_block>
+
+Your previous attempt was blocked by the pre-execution guardrails — it never ran. Fix the issues above and produce a new train.py. Save artifacts under {next_dir}/.""",
+                )
+            )
+            continue
+
+        # 4. Execute with LLM-based log monitoring
+        output = execute_with_monitor(
+            train_py,
+            timeout_seconds=_BASELINE_CODE_TIMEOUT,
+            log_monitor_interval=_LOG_MONITOR_INTERVAL,
+            logger=logger,
+        )
+        (version_dir / "train.txt").write_text(output)
+
+        # 5. Review (one-shot LLM call, NOT part of input_list)
+        try:
+            review = _review(goal_text, code, output)
+        except Exception as exc:
+            logger.exception(
+                "Review LLM call failed at v%s — synthesizing degraded review",
+                version,
+            )
+            review = GoalReview(
+                reasoning=f"review call raised: {exc}",
+                is_valid=False,
+                violations=["review_call_error"],
+                score=float("inf"),
+                done=False,
+                next_step="The review LLM call failed. Try a simpler approach next.",
+            )
+        (version_dir / "review.json").write_text(review.model_dump_json(indent=2))
+
+        history.append(HistoryEntry(version=version, code=code, review=review))
+        logger.info(
+            "v%s: score=%s done=%s violations=%s",
+            version,
+            review.score,
+            review.done,
+            review.violations,
+        )
+
+        if review.done:
+            logger.info("v%s: goal reached, terminating loop", version)
+            break
+
+        # 6. Append the next user instruction
+        input_list.append(
+            append_message("user", next_codegen_user(output, review, next_dir))
+        )
+
+    (run_dir / "history.json").write_text(
+        json.dumps([entry.to_dict() for entry in history], indent=2)
+    )
+    logger.info("history.json written with %d entries", len(history))
+    return history
+
+
+@weave.op()
+def _generate_code(input_list: list[dict]) -> str:
+    """Call the codegen LLM and return the extracted python code."""
+    response = call_llm(
+        model=_DEVELOPER_MODEL,
+        system_instruction=codegen_system(),
+        messages=input_list,
+        text_format=None,
+    )
+    raw_text = response.text or ""
+    code = extract_python_code(raw_text)
+    if not code:
+        raise ValueError("No ```python code block found in model response")
+    return code
+
+
+@weave.op()
+def _review(goal_text: str, code: str, output: str) -> GoalReview:
+    """Run the one-shot review LLM call and return the parsed GoalReview."""
+    return call_llm(
+        model=_DEVELOPER_TOOL_MODEL,
+        system_instruction=review_system(),
+        messages=review_user(goal_text, code, output),
+        text_format=GoalReview,
+    )

--- a/goal_mode.py
+++ b/goal_mode.py
@@ -1,0 +1,168 @@
+"""Top-level entry point for the standalone goal-mode developer agent.
+
+Usage:
+    python goal_mode.py
+    python goal_mode.py --goal-file GOAL.md --run-id abc --max-versions 30
+"""
+
+import argparse
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+import wandb
+import weave
+
+from agents.goal_developer import run_goal_mode
+from project_config import get_config_value
+
+
+def _resolve_wandb_target(
+    cli_entity: Optional[str], cli_project: Optional[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Determine the wandb entity/project from CLI, env vars, or config."""
+    entity = next(
+        (
+            value
+            for value in (
+                cli_entity,
+                os.environ.get("WANDB_ENTITY"),
+                get_config_value("tracking", "wandb", "entity", default=None),
+            )
+            if value
+        ),
+        None,
+    )
+    project = next(
+        (
+            value
+            for value in (
+                cli_project,
+                os.environ.get("WANDB_PROJECT"),
+                get_config_value("tracking", "wandb", "project", default=None),
+            )
+            if value
+        ),
+        None,
+    )
+    return entity, project
+
+
+def _init_tracking(
+    wandb_entity: Optional[str],
+    wandb_project: Optional[str],
+    run_name: str,
+) -> None:
+    """Initialise wandb and weave using the best available configuration."""
+    entity, project = _resolve_wandb_target(wandb_entity, wandb_project)
+
+    if not project:
+        # Fall back to disabled mode so downstream wandb.log calls are no-ops.
+        wandb.init(mode="disabled", name=run_name)
+        return
+
+    wandb_kwargs = {"project": project, "name": run_name}
+    if entity:
+        wandb_kwargs["entity"] = entity
+    wandb.init(**wandb_kwargs)
+    weave_project = f"{entity}/{project}" if entity else project
+    weave.init(project_name=weave_project)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Iterate a generate-execute-review loop against a free-form GOAL.md."
+    )
+    parser.add_argument(
+        "--goal-file",
+        type=Path,
+        default=Path("GOAL.md"),
+        help="Path to the goal description (default: GOAL.md in the current directory).",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        help="Identifier for this run (default: timestamp).",
+    )
+    parser.add_argument(
+        "--max-versions",
+        type=int,
+        default=500,
+        help="Maximum number of iterations (default: 500).",
+    )
+    parser.add_argument(
+        "--max-time-seconds",
+        type=int,
+        default=432 * 3600,
+        help="Wall-clock budget in seconds (default: 432 hours).",
+    )
+    parser.add_argument(
+        "--wandb-entity",
+        type=str,
+        default=None,
+        help="Weights & Biases entity name (overrides env / config).",
+    )
+    parser.add_argument(
+        "--wandb-project",
+        type=str,
+        default=None,
+        help="Weights & Biases project name (overrides env / config).",
+    )
+    parser.add_argument(
+        "--wandb-run-name",
+        type=str,
+        default=None,
+        help="Optional wandb run name override (defaults to 'goal-<run_id>').",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+
+    if not args.goal_file.exists():
+        raise FileNotFoundError(
+            f"Goal file not found: {args.goal_file}. "
+            f"Create one at {args.goal_file.resolve()} or pass --goal-file."
+        )
+
+    goal_text = args.goal_file.read_text()
+    run_id = args.run_id or time.strftime("%Y%m%d_%H%M%S")
+    run_dir = Path("goal_runs") / run_id
+
+    run_name = args.wandb_run_name or f"goal-{run_id}"
+    _init_tracking(args.wandb_entity, args.wandb_project, run_name)
+
+    try:
+        history = run_goal_mode(
+            goal_text=goal_text,
+            run_dir=run_dir,
+            max_versions=args.max_versions,
+            max_time_seconds=args.max_time_seconds,
+        )
+    finally:
+        # Gracefully close tracking backends to avoid hanging background threads.
+        try:
+            weave.finish()
+        except Exception:
+            pass
+        try:
+            wandb.finish()
+        except Exception:
+            pass
+
+    final = history[-1] if history else None
+    final_done = bool(final and final.review and final.review.done)
+    final_score = final.review.score if final and final.review else None
+    print(
+        f"goal_mode finished: {len(history)} iterations, done={final_done}, "
+        f"final_score={final_score}, run_dir={run_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/prompts/goal_developer.py
+++ b/prompts/goal_developer.py
@@ -1,0 +1,96 @@
+"""Prompt builders for the standalone goal-mode agent.
+
+Five pure template-string functions. The agent (`agents/goal_developer.py`)
+threads the codegen calls through a single growing message list — these
+builders just substitute strings into triple-quoted templates and have no
+knowledge of history, truncation, or schemas.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from schemas.goal_developer import GoalReview
+
+
+def codegen_system() -> str:
+    return """You write a single Python script (`train.py`) that iterates toward the goal stated in `<goal>`. Each iteration produces one complete script; the previous attempt is visible above in the conversation thread, along with the reviewer's verdict.
+
+**Hard Constraints:**
+- Place `import logging` and `logging.basicConfig(level=logging.INFO, ...)` at the very top of the script, BEFORE any third-party imports (torch, transformers, numpy, etc.). Third-party libraries configure logging on import, so basicConfig must come first. A pre-execution guardrail enforces this and will block the script otherwise.
+- Use the `logging` module (not `print`) for all observability. Log: what the script is doing at each major step, sizes / shapes / counts of anything loaded, intermediate quantities that can go wrong (thresholds, class weights, normalizations), final results, total runtime, and any errors caught.
+- Do not use `try/except` to suppress errors. Let exceptions propagate so they appear in the log and the reviewer can act on them.
+- Treat any constraints listed in `<goal>` as inviolable. The reviewer will flag violations and the loop will refuse to record the version as progress.
+
+## Output
+- Return a single Python script inside one ```python ... ``` fenced block. No prose outside it.
+- Start the file with a docstring containing your reasoning, the approach, and what changed since the previous version (if any).
+- Save every artifact the script produces inside the version directory printed in the user message.
+- The script must be self-contained and runnable as `python train.py`. stdout/stderr are captured automatically into `train.txt` next to the script.
+
+When the user message includes a previous review with a `next_step`, evolve your previous attempt in that direction. The previous code is visible in the conversation thread above.
+"""
+
+
+def initial_codegen_user(goal_text: str, version_dir: Path) -> str:
+    return f"""<goal>
+{goal_text}
+</goal>
+
+<version_dir>{version_dir}</version_dir>
+
+This is iteration 1. Write the first attempt from scratch.
+
+Output one ```python ... ``` fenced block. Save all artifacts under {version_dir}/.
+"""
+
+
+def next_codegen_user(output: str, review: GoalReview, version_dir: Path) -> str:
+    return f"""<execution_output>
+{output}
+</execution_output>
+
+<review>
+reasoning: {review.reasoning}
+is_valid: {review.is_valid}
+violations: {review.violations}
+score: {review.score}
+done: {review.done}
+next_step: {review.next_step}
+</review>
+
+<version_dir>{version_dir}</version_dir>
+
+Apply the reviewer's `next_step` to your previous attempt. Output one ```python ... ``` fenced block. Save all artifacts under {version_dir}/.
+"""
+
+
+def review_system() -> str:
+    return """You are reviewing one execution of a candidate Python script against a stated goal. Return a structured GoalReview JSON.
+
+## Rules
+- Be strict about violations of any hard constraints listed in `<goal>`. Examples: forbidden imports, forbidden function calls, reading files the goal said not to read, exceeding stated budgets.
+- The `score` field is a lower-is-better progress signal toward the goal. Choose whatever scalar best reflects "distance to done" for this goal (e.g. worst per-tensor relative_err for a clone task, 1 - accuracy for a classifier, mean L2 error for a regression). Use the same metric consistently across iterations so progress is comparable.
+- Set `done=True` ONLY if the goal is fully achieved. Partial progress is not done.
+- `next_step` should be the single most impactful change to try next. If `done=True`, leave `next_step` empty.
+- `is_valid` is True iff the run completed without an unhandled exception and produced the artifacts the script claims to have produced.
+"""
+
+
+def review_user(goal_text: str, code: str, output: str) -> str:
+    return f"""<goal>
+{goal_text}
+</goal>
+
+<candidate_code>
+```python
+{code}
+```
+</candidate_code>
+
+<execution_output>
+{output}
+</execution_output>
+
+Return a GoalReview JSON with: reasoning, is_valid, violations, score, done, next_step.
+"""

--- a/schemas/goal_developer.py
+++ b/schemas/goal_developer.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class GoalReview(BaseModel):
+    """Structured review of a single goal-mode iteration.
+
+    Returned by the review LLM call after each candidate script runs. The
+    framework reads `done` to terminate the loop, `score` to log progress,
+    `violations` to surface hard-constraint failures, and `next_step` to
+    feed the next code-generation call.
+    """
+
+    reasoning: str
+    is_valid: bool
+    violations: list[str]
+    score: float
+    done: bool
+    next_step: str

--- a/tests/test_goal_developer.py
+++ b/tests/test_goal_developer.py
@@ -1,0 +1,195 @@
+"""Unit tests for the standalone goal-mode developer agent."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agents import goal_developer
+from agents.goal_developer import HistoryEntry, run_goal_mode
+from schemas.goal_developer import GoalReview
+
+
+def _fake_llm_response(text: str) -> SimpleNamespace:
+    """Mimic the shape of a genai response with a `.text` attribute."""
+    return SimpleNamespace(text=text)
+
+
+def _hello_script(version_dir: Path) -> str:
+    return (
+        "import logging\n"
+        "logging.basicConfig(level=logging.INFO)\n"
+        "from pathlib import Path\n"
+        f"Path({str(version_dir)!r}).mkdir(parents=True, exist_ok=True)\n"
+        f"Path({str(version_dir)!r}, 'out.txt').write_text('hello')\n"
+        "logging.info('wrote out.txt')\n"
+    )
+
+
+@pytest.fixture
+def fake_pipeline(monkeypatch, tmp_path):
+    """Patch the LLM, log monitor, and guardrails so the loop can run offline."""
+    captured = {"codegen_calls": 0, "review_calls": 0, "executed": []}
+
+    def fake_call_llm(*, model, system_instruction, messages, text_format=None, **kwargs):
+        # First positional usage: codegen pass returns raw text response.
+        if text_format is None:
+            captured["codegen_calls"] += 1
+            version = captured["codegen_calls"]
+            version_dir = tmp_path / "run" / f"v{version}"
+            return _fake_llm_response(
+                "Here is the script:\n```python\n" + _hello_script(version_dir) + "```\n"
+            )
+        # text_format=GoalReview path returns a parsed pydantic instance.
+        captured["review_calls"] += 1
+        return captured["review_factory"](captured["review_calls"])
+
+    monkeypatch.setattr(goal_developer, "call_llm", fake_call_llm)
+
+    def fake_execute_with_monitor(code_path, *, timeout_seconds, log_monitor_interval, logger, conda_env=None):
+        # Actually run the script so out.txt is materialised — exercises the real subprocess too slowly.
+        # We just simulate it: invoke the script via exec() inside this process.
+        captured["executed"].append(Path(code_path))
+        code_text = Path(code_path).read_text()
+        exec_globals: dict = {"__name__": "__main__", "__file__": str(code_path)}
+        try:
+            exec(compile(code_text, str(code_path), "exec"), exec_globals)
+        except Exception as exc:  # pragma: no cover - surfaced via train.txt
+            return f"[exec failed: {exc}]"
+        return "wrote out.txt\n"
+
+    monkeypatch.setattr(goal_developer, "execute_with_monitor", fake_execute_with_monitor)
+
+    # Disable guardrails (the dummy script trivially passes them, but we want determinism).
+    def fake_evaluate_guardrails(**kwargs):
+        return {"decision": "proceed", "logging_check": {}, "leakage_check": {}, "safety_check": {}}
+
+    monkeypatch.setattr(goal_developer, "evaluate_guardrails", fake_evaluate_guardrails)
+
+    captured["review_factory"] = lambda n: GoalReview(
+        reasoning=f"v{n}: looks good",
+        is_valid=True,
+        violations=[],
+        score=0.0,
+        done=True,
+        next_step="",
+    )
+    return captured
+
+
+def test_terminates_on_done(fake_pipeline, tmp_path):
+    """Loop should exit after one iteration when the reviewer says done."""
+    history = run_goal_mode(
+        goal_text="Write `hello` to out.txt",
+        run_dir=tmp_path / "run",
+        max_versions=10,
+        max_time_seconds=60,
+    )
+    assert len(history) == 1
+    assert history[0].review is not None and history[0].review.done is True
+    assert (tmp_path / "run" / "v1" / "train.py").exists()
+    assert (tmp_path / "run" / "v1" / "review.json").exists()
+    assert (tmp_path / "run" / "v1" / "out.txt").read_text() == "hello"
+
+
+def test_iterates_until_max_versions(fake_pipeline, tmp_path):
+    """Loop should run max_versions iterations when the reviewer never says done."""
+    fake_pipeline["review_factory"] = lambda n: GoalReview(
+        reasoning=f"v{n}: not yet",
+        is_valid=True,
+        violations=[],
+        score=1.0,
+        done=False,
+        next_step="keep going",
+    )
+    history = run_goal_mode(
+        goal_text="Write `hello` to out.txt",
+        run_dir=tmp_path / "run",
+        max_versions=3,
+        max_time_seconds=60,
+    )
+    assert len(history) == 3
+    assert all(entry.review and entry.review.done is False for entry in history)
+
+
+def test_review_failure_yields_degraded_entry(fake_pipeline, tmp_path):
+    """When the review LLM raises, the loop synthesises a degraded GoalReview and continues."""
+    calls = {"n": 0}
+
+    def flaky_factory(n):
+        calls["n"] = n
+        if n == 1:
+            raise RuntimeError("review service unreachable")
+        return GoalReview(
+            reasoning="recovered",
+            is_valid=True,
+            violations=[],
+            score=0.0,
+            done=True,
+            next_step="",
+        )
+
+    fake_pipeline["review_factory"] = flaky_factory
+
+    history = run_goal_mode(
+        goal_text="Write `hello` to out.txt",
+        run_dir=tmp_path / "run",
+        max_versions=3,
+        max_time_seconds=60,
+    )
+    assert len(history) == 2
+    assert history[0].review is not None
+    assert history[0].review.violations == ["review_call_error"]
+    assert history[0].review.is_valid is False
+    assert history[1].review is not None and history[1].review.done is True
+
+
+def test_guardrails_block_skips_execution(monkeypatch, fake_pipeline, tmp_path):
+    """A guardrails block should skip execution and review, and append a fix-it message."""
+    blocks = {"count": 0}
+
+    def block_then_proceed(**kwargs):
+        blocks["count"] += 1
+        if blocks["count"] == 1:
+            return {
+                "decision": "block",
+                "logging_check": {"status": "fail", "violations": [{"line": 1, "reason": "bad order"}]},
+                "leakage_check": {},
+                "safety_check": {"decision": "proceed"},
+            }
+        return {"decision": "proceed", "logging_check": {}, "leakage_check": {}, "safety_check": {}}
+
+    monkeypatch.setattr(goal_developer, "evaluate_guardrails", block_then_proceed)
+
+    history = run_goal_mode(
+        goal_text="Write `hello` to out.txt",
+        run_dir=tmp_path / "run",
+        max_versions=3,
+        max_time_seconds=60,
+    )
+    # v1 was blocked, v2 ran and the reviewer marked it done.
+    assert len(history) == 2
+    assert history[0].review is None  # blocked, never reviewed
+    assert (tmp_path / "run" / "v1" / "guardrails_block.txt").exists()
+    assert (tmp_path / "run" / "v1" / "train.txt").exists() is False
+    assert history[1].review is not None and history[1].review.done is True
+    assert fake_pipeline["executed"] == [tmp_path / "run" / "v2" / "train.py"]
+
+
+def test_history_json_persisted(fake_pipeline, tmp_path):
+    """history.json should round-trip the recorded entries."""
+    run_goal_mode(
+        goal_text="Write `hello` to out.txt",
+        run_dir=tmp_path / "run",
+        max_versions=10,
+        max_time_seconds=60,
+    )
+    history_path = tmp_path / "run" / "history.json"
+    assert history_path.exists()
+    payload = json.loads(history_path.read_text())
+    assert isinstance(payload, list) and len(payload) == 1
+    assert payload[0]["version"] == 1
+    assert payload[0]["review"]["done"] is True

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -748,3 +748,62 @@ def monitor_logs(
         text_format=LogMonitorVerdict,
     )
     return response
+
+
+def execute_with_monitor(
+    code_path: str | Path,
+    *,
+    timeout_seconds: int,
+    log_monitor_interval: int,
+    logger: logging.Logger,
+    conda_env: str | None = None,
+) -> str:
+    """Launch a Python file with LLM-based log monitoring; return captured output.
+
+    Polls the running ExecutionJob every ``log_monitor_interval`` seconds and
+    calls ``monitor_logs`` to decide whether the process should be killed.
+    Returns the output from ``ExecutionJob.result()`` (stdout on success,
+    ``web_search_stack_trace(stderr)`` advisory on failure).
+    """
+    job = execute_code(
+        str(code_path),
+        timeout_seconds=timeout_seconds,
+        conda_env=conda_env,
+    )
+    logger.info(
+        "Launched execution for %s (pid=%d, timeout=%ds)",
+        code_path,
+        job.pid,
+        timeout_seconds,
+    )
+
+    while not job.done():
+        if job.check_timeout():
+            logger.warning("Hard timeout reached for %s", code_path)
+            return job.kill("Hard timeout exceeded")
+
+        try:
+            verdict = monitor_logs(
+                log_output=job.recent_output(),
+                seconds_since_last_output=job.idle_time(),
+                total_elapsed_seconds=job.elapsed(),
+                pid=job.pid,
+            )
+            logger.info(
+                "Monitor verdict for %s: %s (%s)",
+                code_path,
+                verdict.action,
+                verdict.reasoning,
+            )
+            if verdict.action == "kill":
+                return job.kill(verdict.reasoning)
+        except Exception:
+            logger.exception(
+                "Monitor call failed for %s — continuing execution", code_path
+            )
+
+        time.sleep(log_monitor_interval)
+
+    output = job.result()
+    logger.info("Execution output captured for %s", code_path)
+    return output


### PR DESCRIPTION
Addresses #203 

## Summary
- Adds a standalone goal-mode developer agent that reads a free-form `GOAL.md` from the repo root and iterates a generate-execute-review loop until the reviewer reports `done` or limits hit.
- New entry point `goal_mode.py` (`python goal_mode.py [--goal-file GOAL.md] [--run-id ID] [--max-versions N] [--max-time-seconds S]`). Per-run artifacts land under `goal_runs/<run_id>/v<N>/{train.py, train.txt, review.json}` with a summary `history.json` at the run root.
- Loop body:
  1. Codegen LLM call (`llm.developer_model`) — message thread grows across iterations like the existing developer flow at `agents/developer.py:1486-1498`.
  2. Pre-execution guardrails — same `evaluate_guardrails` / `build_block_summary` from `utils/guardrails.py` that the existing developer uses (logging-order check, leakage review, code safety). Blocked candidates skip execution and feed a fix-it instruction back into the thread.
  3. Execution via the new shared `tools.developer.execute_with_monitor` (extracted from `DeveloperAgent._execute_code`; reuses the existing log-monitor polling loop). Both `agents/developer.py` and `agents/goal_developer.py` call it now.
  4. One-shot review LLM call (`llm.developer_tool_model`) returns a `GoalReview` JSON (`reasoning`, `is_valid`, `violations`, `score`, `done`, `next_step`). On exception the loop synthesises a degraded review and keeps going.
- New files: `agents/goal_developer.py`, `prompts/goal_developer.py`, `schemas/goal_developer.py`, `goal_mode.py`, `tests/test_goal_developer.py`.
- `agents/developer.py:_execute_code` is now a thin wrapper around `execute_with_monitor` — behavior is byte-identical for the existing flow.
- `.gitignore` adds `goal_runs/` and `GOAL.md` (mirrors the `INSTRUCTIONS.md` treatment — user-local, not a repo artifact).

## Test plan
- [x] `pytest tests/test_goal_developer.py -v` — 5 new tests pass (terminates on done, iterates to max_versions, degraded review on failure, guardrails-block skips execution, history.json persisted).
- [x] `pytest tests/test_developer_agent.py tests/test_developer_tools.py -v` — 22 existing tests still pass (validates the `execute_with_monitor` extract-method refactor).
- [x] `pytest tests/ -v` — full suite green (40 passed).
- [x] `python -m compileall agents/goal_developer.py prompts/goal_developer.py schemas/goal_developer.py tests/test_goal_developer.py goal_mode.py tools/developer.py agents/developer.py` — clean.
- [x] `python goal_mode.py --help` renders the CLI usage.