### PR TITLE
enable web search for goal mode codegen and review (#208)

### DIFF
--- a/agents/goal_developer.py
+++ b/agents/goal_developer.py
@@ -198,6 +198,7 @@ def _generate_code(input_list: list[dict]) -> str:
         system_instruction=codegen_system(),
         messages=input_list,
         text_format=None,
+        enable_google_search=True,
     )
     raw_text = response.text or ""
     code = extract_python_code(raw_text)
@@ -214,4 +215,5 @@ def _review(goal_text: str, code: str, output: str) -> GoalReview:
         system_instruction=review_system(),
         messages=review_user(goal_text, code, output),
         text_format=GoalReview,
+        enable_google_search=True,
     )

--- a/prompts/goal_developer.py
+++ b/prompts/goal_developer.py
@@ -72,7 +72,7 @@ def review_system() -> str:
 - Be strict about violations of any hard constraints listed in `<goal>`. Examples: forbidden imports, forbidden function calls, reading files the goal said not to read, exceeding stated budgets.
 - The `score` field is a lower-is-better progress signal toward the goal. Choose whatever scalar best reflects "distance to done" for this goal (e.g. worst per-tensor relative_err for a clone task, 1 - accuracy for a classifier, mean L2 error for a regression). Use the same metric consistently across iterations so progress is comparable.
 - Set `done=True` ONLY if the goal is fully achieved. Partial progress is not done.
-- `next_step` should be the single most impactful change to try next. If `done=True`, leave `next_step` empty.
+- `next_step` should be the single most impactful change to try next. Use web search to find better approaches, techniques, or library APIs that could help — don't rely solely on what you already know. If `done=True`, leave `next_step` empty.
 - `is_valid` is True iff the run completed without an unhandled exception and produced the artifacts the script claims to have produced.
 """
 


### PR DESCRIPTION
## Summary
- Passes `enable_google_search=True` to both the codegen and review `call_llm` calls in `agents/goal_developer.py`.
- Updates the review system prompt in `prompts/goal_developer.py` to instruct the reviewer to use web search to find better approaches, techniques, and library APIs when suggesting `next_step`.

Closes #208.

## Test plan
- [x] `pytest tests/test_goal_developer.py -q` — 5 passed