### PR TITLE
move goal text into goal mode codegen system prompt

### DIFF
--- a/agents/goal_developer.py
+++ b/agents/goal_developer.py
@@ -86,7 +86,7 @@ def run_goal_mode(
 
     v1_dir = run_dir / "v1"
     input_list: list[dict] = [
-        append_message("user", initial_codegen_user(goal_text, v1_dir))
+        append_message("user", initial_codegen_user(v1_dir))
     ]
 
     deadline = time.monotonic() + max_time_seconds
@@ -102,7 +102,7 @@ def run_goal_mode(
 
         # 1. Generate code
         try:
-            code = _generate_code(input_list)
+            code = _generate_code(input_list, goal_text)
         except Exception:
             logger.exception("Code generation failed at v%s — aborting loop", version)
             break
@@ -205,23 +205,27 @@ def _execute_goal_tool_call(function_call) -> str:
 
 
 @weave.op()
-def _generate_code(input_list: list[dict]) -> str:
+def _generate_code(input_list: list[dict], goal_text: str) -> str:
     """Call the codegen LLM and return the extracted python code.
 
     Mirrors the multi-step tool loop in ``agents/developer.py:_generate_code``:
     up to ``max_tool_steps`` rounds where the LLM may call ``explore_codebase``
     before producing the final ```python``` block. Tool-call results are
     appended to ``input_list`` so the next call sees them.
+
+    The goal is embedded in the system prompt (not the user thread) so that
+    it is preserved across every call regardless of conversation trimming.
     """
     tools = get_developer_tools()
     max_tool_steps = 100
+    system_prompt = codegen_system(goal_text)
 
     for step in range(max_tool_steps + 1):
         is_last_step = step == max_tool_steps
 
         response = call_llm(
             model=_DEVELOPER_MODEL,
-            system_instruction=codegen_system(),
+            system_instruction=system_prompt,
             messages=input_list,
             text_format=None,
             function_declarations=tools if not is_last_step else [],

--- a/prompts/goal_developer.py
+++ b/prompts/goal_developer.py
@@ -13,8 +13,12 @@ from pathlib import Path
 from schemas.goal_developer import GoalReview
 
 
-def codegen_system() -> str:
-    return """You write a single Python script (`train.py`) that iterates toward the goal stated in `<goal>`. Each iteration produces one complete script; the previous attempt is visible above in the conversation thread, along with the reviewer's verdict.
+def codegen_system(goal_text: str) -> str:
+    return f"""You write a single Python script (`train.py`) that iterates toward the goal stated in `<goal>` below. Each iteration produces one complete script; the previous attempt is visible above in the conversation thread, along with the reviewer's verdict.
+
+<goal>
+{goal_text}
+</goal>
 
 **Hard Constraints:**
 - Place `import logging` and `logging.basicConfig(level=logging.INFO, ...)` at the very top of the script, BEFORE any third-party imports (torch, transformers, numpy, etc.). Third-party libraries configure logging on import, so basicConfig must come first. A pre-execution guardrail enforces this and will block the script otherwise.
@@ -32,12 +36,8 @@ When the user message includes a previous review with a `next_step`, evolve your
 """
 
 
-def initial_codegen_user(goal_text: str, version_dir: Path) -> str:
-    return f"""<goal>
-{goal_text}
-</goal>
-
-<version_dir>{version_dir}</version_dir>
+def initial_codegen_user(version_dir: Path) -> str:
+    return f"""<version_dir>{version_dir}</version_dir>
 
 This is iteration 1. Write the first attempt from scratch.
 


### PR DESCRIPTION
## Summary
- Moves the GOAL.md text from the first user message into the goal-mode codegen system prompt. The system prompt is sent on every `call_llm` call, so the goal is now preserved across every iteration regardless of conversation thread trimming, and it is no longer buried under accumulated `<execution_output>` / `<review>` turns as the loop runs.
- Matches the existing developer flow's pattern: `prompts/developer_agent.py:build_system` already embeds the competition description into the system prompt, so goal mode is now consistent with that.

## Changes
- `prompts/goal_developer.py:codegen_system(goal_text)` — now takes `goal_text` and embeds a `<goal>...</goal>` block at the top of the system prompt.
- `prompts/goal_developer.py:initial_codegen_user(version_dir)` — drops the `goal_text` parameter and the `<goal>` block; iteration 1's user message is now just the kickoff instruction with the version directory.
- `agents/goal_developer.py:_generate_code(input_list, goal_text)` — accepts `goal_text` and computes `system_prompt = codegen_system(goal_text)` once, reusing it across the multi-step tool loop.
- `agents/goal_developer.py:run_goal_mode` — passes `goal_text` into `_generate_code` and into `initial_codegen_user`'s replacement signature.

## Test plan
- [x] `pytest tests/test_goal_developer.py tests/test_explore.py -q` — 26 passed.