### PR TITLE
add execute_python tool to codegen (#216)

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -13,6 +13,8 @@ import weave
 import wandb
 
 from tools.developer import (
+    _build_resource_header,
+    execute_code,
     execute_with_monitor,
     search_red_flags,
     search_sota_suggestions,
@@ -249,13 +251,14 @@ class DeveloperAgent:
 
     @weave.op()
     def _generate_code(
-        self, instructions: str, messages: list[dict[str, str]]
+        self, instructions: str, messages: list[dict[str, str]], version: int
     ) -> tuple[list[dict], str, int | None]:
         """Generate code via markdown-fenced output.
 
         The model can call explore_codebase to read project source files and
-        installed package source before producing its final code output. Up
-        to 100 tool rounds are allowed before the model must emit code.
+        installed package source, or execute_python to run snippets in a
+        subprocess, before producing its final code output. Up to 100 tool
+        rounds are allowed before the model must emit code.
 
         Returns:
             Tuple of (message_history, train_py_code, input_tokens)
@@ -309,12 +312,15 @@ class DeveloperAgent:
 
                 return output, code, input_tokens
 
-            # Execute tool calls (explore_codebase)
+            # Execute tool calls (explore_codebase / execute_python)
             function_responses = []
-            for part in parts:
+            for call_idx, part in enumerate(parts, start=1):
                 if hasattr(part, "function_call") and part.function_call:
                     result_str = self._execute_developer_tool_call(
-                        part.function_call
+                        part.function_call,
+                        version=version,
+                        step=step + 1,
+                        call_idx=call_idx,
                     )
                     function_responses.append(
                         types.Part.from_function_response(
@@ -332,7 +338,14 @@ class DeveloperAgent:
         # Should not reach here (last step has no tools so model must produce text)
         raise RuntimeError("Code generation exhausted tool steps without producing code")
 
-    def _execute_developer_tool_call(self, function_call) -> str:
+    def _execute_developer_tool_call(
+        self,
+        function_call,
+        *,
+        version: int,
+        step: int,
+        call_idx: int,
+    ) -> str:
         """Dispatch a tool call made during code generation."""
         args = dict(function_call.args)
 
@@ -340,6 +353,31 @@ class DeveloperAgent:
             query = args["query"]
             self.logger.info("explore_codebase called: %s", query[:100])
             return explore_codebase(query)
+
+        if function_call.name == "execute_python":
+            code = args["code"]
+            timeout = args.get("timeout_seconds", 300)
+            self.logger.info(
+                "execute_python called (v%s step %s call %s, %d bytes, timeout=%ds)",
+                version,
+                step,
+                call_idx,
+                len(code),
+                timeout,
+            )
+            work_dir = self.outputs_dir / str(version) / "codegen_snippets"
+            work_dir.mkdir(parents=True, exist_ok=True)
+            script_file = work_dir / f"{step}_{call_idx}.py"
+            resource_header = _build_resource_header(
+                self.cpu_core_range, self.gpu_identifier
+            )
+            script_file.write_text(resource_header + code)
+            job = execute_code(
+                str(script_file),
+                timeout_seconds=timeout,
+                conda_env=self.conda_env,
+            )
+            return json.dumps({"output": job.result()})
 
         return json.dumps({"error": f"Unknown tool: {function_call.name}"})
 
@@ -1438,7 +1476,7 @@ Fix the error. Write logs to {next_log_path} and save all required artifacts to 
 
             try:
                 response_output, train_py, last_input_tokens = self._generate_code(
-                    instructions=system_prompt, messages=input_list
+                    instructions=system_prompt, messages=input_list, version=version
                 )
             except (ValueError, RuntimeError) as e:
                 self.logger.warning(

--- a/agents/goal_developer.py
+++ b/agents/goal_developer.py
@@ -27,7 +27,11 @@ from prompts.goal_developer import (
     review_user,
 )
 from schemas.goal_developer import GoalReview
-from tools.developer import execute_with_monitor
+from tools.developer import (
+    _build_resource_header,
+    execute_code,
+    execute_with_monitor,
+)
 from tools.explore import explore_codebase
 from tools.helpers import call_llm
 from utils.code_utils import extract_python_code
@@ -102,7 +106,7 @@ def run_goal_mode(
 
         # 1. Generate code
         try:
-            code = _generate_code(input_list, goal_text)
+            code = _generate_code(input_list, goal_text, version_dir)
         except Exception:
             logger.exception("Code generation failed at v%s — aborting loop", version)
             break
@@ -192,7 +196,13 @@ Your previous attempt was blocked by the pre-execution guardrails — it never r
     return history
 
 
-def _execute_goal_tool_call(function_call) -> str:
+def _execute_goal_tool_call(
+    function_call,
+    *,
+    version_dir: Path,
+    step: int,
+    call_idx: int,
+) -> str:
     """Dispatch a tool call made during goal-mode code generation."""
     args = dict(function_call.args)
 
@@ -201,17 +211,35 @@ def _execute_goal_tool_call(function_call) -> str:
         logger.info("explore_codebase called: %s", query[:100])
         return explore_codebase(query)
 
+    if function_call.name == "execute_python":
+        code = args["code"]
+        timeout = args.get("timeout_seconds", 300)
+        logger.info(
+            "execute_python called (step %s call %s, %d bytes, timeout=%ds)",
+            step,
+            call_idx,
+            len(code),
+            timeout,
+        )
+        work_dir = version_dir / "codegen_snippets"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        script_file = work_dir / f"{step}_{call_idx}.py"
+        resource_header = _build_resource_header(None, None)
+        script_file.write_text(resource_header + code)
+        job = execute_code(str(script_file), timeout_seconds=timeout)
+        return json.dumps({"output": job.result()})
+
     return json.dumps({"error": f"Unknown tool: {function_call.name}"})
 
 
 @weave.op()
-def _generate_code(input_list: list[dict], goal_text: str) -> str:
+def _generate_code(input_list: list[dict], goal_text: str, version_dir: Path) -> str:
     """Call the codegen LLM and return the extracted python code.
 
     Mirrors the multi-step tool loop in ``agents/developer.py:_generate_code``:
     up to ``max_tool_steps`` rounds where the LLM may call ``explore_codebase``
-    before producing the final ```python``` block. Tool-call results are
-    appended to ``input_list`` so the next call sees them.
+    or ``execute_python`` before producing the final ```python``` block.
+    Tool-call results are appended to ``input_list`` so the next call sees them.
 
     The goal is embedded in the system prompt (not the user thread) so that
     it is preserved across every call regardless of conversation trimming.
@@ -247,9 +275,14 @@ def _generate_code(input_list: list[dict], goal_text: str) -> str:
             return code
 
         function_responses = []
-        for part in parts:
+        for call_idx, part in enumerate(parts, start=1):
             if hasattr(part, "function_call") and part.function_call:
-                tool_result_str = _execute_goal_tool_call(part.function_call)
+                tool_result_str = _execute_goal_tool_call(
+                    part.function_call,
+                    version_dir=version_dir,
+                    step=step + 1,
+                    call_idx=call_idx,
+                )
                 function_responses.append(
                     types.Part.from_function_response(
                         name=part.function_call.name,

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -304,4 +304,28 @@ def get_developer_tools():
                 "required": ["query"],
             },
         ),
+        types.FunctionDeclaration(
+            name="execute_python",
+            description=(
+                "Run a Python snippet in a fresh subprocess and get back stdout, "
+                "stderr, and the exit code. Use this to VERIFY behavior — test an "
+                "import, probe an API, check a library version, prototype a function, "
+                "run a quick computation. The snippet runs with a timeout. Use this "
+                "tool when you would otherwise be guessing whether something works."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "Python source code to execute.",
+                    },
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "description": "Hard timeout in seconds (default: 300).",
+                    },
+                },
+                "required": ["code"],
+            },
+        ),
     ]


### PR DESCRIPTION
## Summary
- Adds `execute_python` as a second function-call tool alongside `explore_codebase` in `utils/llm_utils.py:get_developer_tools`. The codegen LLM (in both `agents/developer.py` and `agents/goal_developer.py`) can now run Python snippets in a subprocess to verify behavior — testing imports, probing APIs, prototyping a function — instead of guessing or asking the explore subagent to predict what would happen.
- Wires the new dispatch branch in both `_execute_developer_tool_call` (developer.py) and `_execute_goal_tool_call` (goal_developer.py). The branch inlines the same 5-line pattern that SOTA (`tools/developer.py:_execute_sota_tool_call:439-452`) and the researcher (`agents/researcher.py:205-233`) already use: write the snippet to a file under a per-version subdir, prepend a resource header via `_build_resource_header`, run via the existing `tools.developer.execute_code(...).result()`, return a JSON envelope `{"output": ...}`. No new helper, no new module — just two new imports and ~20 lines of dispatch.
- Threads `version` (developer.py) / `version_dir` (goal_developer.py) plus `step` and `call_idx` through `_generate_code` → dispatcher so each snippet lands at a deterministic, sortable, collision-free filename.
- Snippet filename convention: `<work_dir>/codegen_snippets/<step>_<call_idx>.py` where both indices are 1-based. `step` is the codegen tool-loop round; `call_idx` is the position of the function_call within that round (handles parallel function calls in one round).
  - Example: `outputs/iter1/v3/codegen_snippets/2_2.py` = version 3's second tool-loop round, second parallel call within that round.

This is the first half of fixing #216. The follow-up PR will tighten the `explore_codebase` description and add an entry-point command-shape rejection that points the LLM at `execute_python` as the legitimate alternative.

## Test plan
- [x] `pytest tests/ -q` — 61 passed.
- [x] `python -c "from agents.developer import DeveloperAgent; from agents.goal_developer import run_goal_mode; from utils.llm_utils import get_developer_tools; print(len(get_developer_tools()))"` — prints `2`.