### PR TITLE
tighten explore_codebase tool description (#216)

### DIFF
--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -292,7 +292,18 @@ def get_developer_tools():
     return [
         types.FunctionDeclaration(
             name="explore_codebase",
-            description="Explore the codebase and installed Python packages to answer questions about implementations, APIs, file layouts, and existing patterns. A read-only sub-agent uses Read/Glob/Grep/Bash tools across the configured roots and returns a markdown report. Use this whenever you need to understand existing code before writing new code.",
+            description=(
+                "Ask a natural-language question about the codebase or installed Python "
+                "packages and get back a markdown report with file:line citations. The "
+                "sub-agent reads source files using read_file/glob_files/grep_code/list_dir "
+                "across configured roots — it does NOT execute Python or shell commands. "
+                "To verify whether a snippet runs, use `execute_python` instead.\n\n"
+                "Use this for static investigation: 'How does X work?', 'What's the "
+                "signature of Y?', 'Where is Z defined?', 'Show me callers of W'. Brief "
+                "the sub-agent like a smart colleague who just walked into the room — it "
+                "hasn't seen this conversation. Terse command-style prompts produce "
+                "shallow, generic work."
+            ),
             parameters_json_schema={
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Summary

- Rewrites the `explore_codebase` tool description in `utils/llm_utils.py:get_developer_tools` to clearly distinguish read-only investigation from execution, and to point the codegen LLM at `execute_python` (added in #217) as the alternative when it actually wants to run something.
- **No runtime command-shape rejection** — trusting the LLM to follow the tighter tool description, with `execute_python` as the legitimate alternative path.

The two problems with the old description:

1. It said the sub-agent uses `Read/Glob/Grep/Bash` tools — the LLM latched onto "Bash" and assumed the sub-agent was a code runner.
2. It didn't clarify that the sub-agent does NOT execute anything.

New description:

- Drops the `Bash` mention.
- Adds an explicit "does NOT execute Python or shell commands" sentence.
- Adds an explicit pointer at `execute_python` for the execution use case.
- Adds positive examples of good queries ("How does X work?", "Where is Z defined?", etc.).
- Stacked on #217 because the new description references `execute_python` by name.

Together with #217, closes #216.

## Test plan

- [x] `pytest tests/ -q` — 61 passed (no regressions; the description text isn't asserted anywhere).
- [x] `python -c "from utils.llm_utils import get_developer_tools; print(get_developer_tools()[0].description)"` — confirms the new text is in place.