### PR TITLE
switch goal mode review to anthropic claude with web search

### DIFF
--- a/agents/goal_developer.py
+++ b/agents/goal_developer.py
@@ -15,6 +15,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+import anthropic
 import weave
 from google.genai import types
 
@@ -51,6 +52,13 @@ _DEVELOPER_MODEL = _LLM_CFG["developer_model"]
 _DEVELOPER_TOOL_MODEL = _LLM_CFG["developer_tool_model"]
 _BASELINE_CODE_TIMEOUT = _RUNTIME_CFG["baseline_code_timeout"]
 _LOG_MONITOR_INTERVAL = _RUNTIME_CFG["log_monitor_interval"]
+
+# Goal-mode review uses Anthropic Claude Opus 4.6 with structured output
+# (`output_format=GoalReview`) and the server-side `web_search_20260209`
+# tool, both in a single `messages.parse` call.
+_REVIEW_MODEL = "claude-opus-4-6"
+_REVIEW_MAX_TOKENS = 16384
+_ANTHROPIC_CLIENT = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY from env / .env
 
 _ENABLE_LOGGING_GUARD = bool(_GUARDRAIL_CFG["logging_basicconfig_order"])
 _ENABLE_LEAKAGE_GUARD = bool(_GUARDRAIL_CFG["leakage_review"])
@@ -305,11 +313,30 @@ def _generate_code(input_list: list[dict], goal_text: str, version_dir: Path) ->
 
 @weave.op()
 def _review(goal_text: str, code: str, output: str) -> GoalReview:
-    """Run the one-shot review LLM call and return the parsed GoalReview."""
-    return call_llm(
-        model=_DEVELOPER_TOOL_MODEL,
-        system_instruction=review_system(),
-        messages=review_user(goal_text, code, output),
-        text_format=GoalReview,
-        enable_google_search=True,
+    """Run the one-shot review LLM call and return the parsed GoalReview.
+
+    Uses Anthropic Claude Opus 4.6 with structured output (``output_format``)
+    and the server-side ``web_search_20260209`` tool, both in a single
+    ``messages.parse`` call. The model can web-search for better techniques
+    while reasoning about the run, then emits a JSON GoalReview that matches
+    the pydantic schema directly.
+    """
+    parsed = _ANTHROPIC_CLIENT.messages.parse(
+        model=_REVIEW_MODEL,
+        max_tokens=_REVIEW_MAX_TOKENS,
+        system=review_system(),
+        messages=[
+            {
+                "role": "user",
+                "content": review_user(goal_text, code, output),
+            }
+        ],
+        output_format=GoalReview,
+        tools=[
+            {
+                "name": "web_search",
+                "type": "web_search_20260209",
+            }
+        ],
     )
+    return parsed.parsed_output

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,6 +9,7 @@ numpy
 kaggle
 kagglehub
 google-genai
+anthropic
 PyYAML
 requests
 firecrawl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ seaborn
 torchgeo
 scikit-image
 google-genai
+anthropic

--- a/tests/test_goal_developer.py
+++ b/tests/test_goal_developer.py
@@ -45,19 +45,21 @@ def fake_pipeline(monkeypatch, tmp_path):
     captured = {"codegen_calls": 0, "review_calls": 0, "executed": []}
 
     def fake_call_llm(*, model, system_instruction, messages, text_format=None, **kwargs):
-        # First positional usage: codegen pass returns raw text response.
-        if text_format is None:
-            captured["codegen_calls"] += 1
-            version = captured["codegen_calls"]
-            version_dir = tmp_path / "run" / f"v{version}"
-            return _fake_llm_response(
-                "Here is the script:\n```python\n" + _hello_script(version_dir) + "```\n"
-            )
-        # text_format=GoalReview path returns a parsed pydantic instance.
+        # Codegen path uses call_llm; the review path now bypasses it and
+        # calls the Anthropic SDK directly, so this mock only handles codegen.
+        captured["codegen_calls"] += 1
+        version = captured["codegen_calls"]
+        version_dir = tmp_path / "run" / f"v{version}"
+        return _fake_llm_response(
+            "Here is the script:\n```python\n" + _hello_script(version_dir) + "```\n"
+        )
+
+    def fake_review(goal_text, code, output):
         captured["review_calls"] += 1
         return captured["review_factory"](captured["review_calls"])
 
     monkeypatch.setattr(goal_developer, "call_llm", fake_call_llm)
+    monkeypatch.setattr(goal_developer, "_review", fake_review)
 
     def fake_execute_with_monitor(code_path, *, timeout_seconds, log_monitor_interval, logger, conda_env=None):
         # Actually run the script so out.txt is materialised — exercises the real subprocess too slowly.


### PR DESCRIPTION
## Summary
Switches the goal-mode review LLM call (`agents/goal_developer.py:_review`) from Gemini to **Anthropic Claude Opus 4.6** with structured output and the server-side `web_search_20260209` tool, both in a single `messages.parse(...)` call. The codegen path (`_generate_code`) is unchanged — still Gemini.

## Why
1. Claude Opus 4.6 produces more rigorous structured-output verdicts for adversarial code review than the prior Gemini call did (verified end-to-end with the demo at `demos/goal_review_call.py` against the same 92k-token GOAL/CANDIDATE/OUTPUT inputs that triggered the original misuse trace).
2. Anthropic's server-side `web_search_20260209` lets the reviewer ground its `next_step` suggestions in real documentation when the local context is insufficient, with citations.
3. Per the Anthropic SDK design, structured output (`output_format=GoalReview`) and the web_search tool **compose in a single API call** — no multi-turn loop or `tool_choice` gymnastics needed. `output_format` constrains the final response; tools are mid-call actions; they live at different layers.

## Changes
- **`agents/goal_developer.py`**:
  - `import anthropic`
  - New module-level constants: `_REVIEW_MODEL = "claude-opus-4-6"`, `_REVIEW_MAX_TOKENS = 16384`, `_ANTHROPIC_CLIENT = anthropic.Anthropic()` (reads `ANTHROPIC_API_KEY` from `.env`)
  - `_review` rewritten to call `_ANTHROPIC_CLIENT.messages.parse(model=_REVIEW_MODEL, max_tokens=_REVIEW_MAX_TOKENS, system=review_system(), messages=[{"role": "user", "content": review_user(...)}], output_format=GoalReview, tools=[{"name": "web_search", "type": "web_search_20260209"}])` and return `parsed.parsed_output` directly. **No defensive `getattr` / `or ""` fallbacks** — `parsed.parsed_output` is a typed property of `ParsedMessage` that always exists on a successful return. Failures propagate to the existing try/except in `run_goal_mode` which synthesises a degraded review.
  - The existing `@weave.op()` decorator stays — weave records inputs/outputs at the function boundary regardless of the underlying SDK.

- **`tests/test_goal_developer.py`**:
  - `fake_pipeline` fixture updated. The old `fake_call_llm` dispatched on `text_format` to handle both codegen and review; with the review now bypassing `call_llm` entirely, that branch was dead. Stripped it (`fake_call_llm` is codegen-only now) and added a separate `fake_review` patch via `monkeypatch.setattr(goal_developer, "_review", ...)`. The 5 existing tests (including `test_review_failure_yields_degraded_entry`, which intentionally raises in `_review`) all pass without other changes.

- **`requirements.txt`**: adds `anthropic` (already installed at v0.93.0 in the active venv).

## Test plan
- [x] `pytest tests/test_goal_developer.py -v` — 5 passed.
- [x] `python -c "from agents.goal_developer import _review, _ANTHROPIC_CLIENT, _REVIEW_MODEL, _REVIEW_MAX_TOKENS; print(_REVIEW_MODEL, _REVIEW_MAX_TOKENS)"` — prints `claude-opus-4-6 16384`.
- [x] Verified end-to-end against the real Anthropic API via a standalone reproducer at `demos/goal_review_call.py` (not committed; uses the exact 92k-token inputs from the original trace). Returned `stop_reason="end_turn"`, `output_tokens=883`, and a fully-populated `GoalReview` correctly diagnosing the `HarmonyError` plus the missing CSV outputs from the original failure.

## Out of scope
- The codegen path (`_generate_code`) stays on Gemini. Porting it would require wiring the multi-step tool loop (`explore_codebase`, `execute_python`) through the Anthropic SDK with `function_calling`, which is a separate, larger change.
- SOTA / researcher / red-flags / log-monitor stay on Gemini.
- No `config.yaml` knob for the review model — the goal-mode review is intentionally a single-purpose call with one recommended model. Edit the constant if you want to swap.