### PR TITLE
auto-download kaggle competition data before agent run (#154)

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -15,6 +15,7 @@ from utils.checkpoint import (
     create_db as _create_checkpoint_db,
     delete_checkpoints_after,
 )
+from utils.competition_data import download_competition_data
 from weave.trace.util import ThreadPoolExecutor
 import weave
 
@@ -393,6 +394,9 @@ class Orchestrator:
 
     @weave.op()
     def run(self) -> tuple[bool, str]:
+        # Phase 0: Ensure raw competition data is on disk before any agent runs.
+        download_competition_data(self.slug, self.base_dir)
+
         # Phase 1: Starter Agent - Get task type and summary
         starter_suggestion_path = self.outputs_dir / "starter_suggestions.json"
         if not starter_suggestion_path.exists():

--- a/utils/competition_data.py
+++ b/utils/competition_data.py
@@ -1,0 +1,37 @@
+"""Download raw Kaggle competition data into ``task/<slug>/``."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from dotenv import load_dotenv
+import kagglehub
+
+logger = logging.getLogger(__name__)
+
+
+def download_competition_data(slug: str, target_dir: Path) -> None:
+    """Download ``slug`` from Kaggle and mirror it into ``target_dir``.
+
+    Wraps ``kagglehub.competition_download`` — which transparently caches under
+    ``~/.cache/kagglehub/competitions/<slug>/`` and re-downloads when Kaggle
+    publishes a new dataset version — and copies the cache contents to
+    ``target_dir``. Fails loudly on missing credentials / network errors.
+    """
+
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    load_dotenv()
+
+    cache_path = Path(kagglehub.competition_download(slug))
+    for entry in cache_path.iterdir():
+        dest = target_dir / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, dest, dirs_exist_ok=True)
+        else:
+            shutil.copy2(entry, dest)
+
+    logger.info("Synced competition data for slug=%s from %s to %s",
+                slug, cache_path, target_dir)


### PR DESCRIPTION
## Summary
- Adds `utils/competition_data.py` with `download_competition_data(slug, target_dir)` — wraps `kagglehub.competition_download`, `load_dotenv()`s for `KAGGLE_API_TOKEN`, and mirrors the kagglehub cache into `task/<slug>/`.
- Invokes it as Phase 0 at the top of `Orchestrator.run()` (before `StarterAgent`), so fresh machines no longer need a manual `kagglehub.competition_download` + `mv` dance.
- Resolves #154.

## Test plan
- [x] `python -c "from utils.competition_data import download_competition_data"` and `from agents.orchestrator import Orchestrator` both import cleanly.
- [ ] Run `python launch_agent.py --slug neurogolf-2026 --iteration 1` on a clean `task/neurogolf-2026/` and confirm files land before the StarterAgent log line.