### PR TITLE
wire in deep research subagent (#141)

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -8,6 +8,7 @@ from queue import Queue
 
 from agents.developer import DeveloperAgent
 from project_config import get_config, get_instructions
+from tools.research import deep_research
 from tools.helpers import _build_directory_listing
 from utils.checkpoint import (
     create_db as _create_checkpoint_db,
@@ -397,14 +398,18 @@ class Orchestrator:
         # Phase 0: Ensure raw competition data is on disk before any agent runs.
         download_competition_data(self.slug, self.base_dir)
 
-        # Phase 1: Researcher subagent — re-wired in a follow-up PR.
-        plan_path = self.outputs_dir / "plan.md"
-        if not plan_path.exists():
-            raise RuntimeError(
-                "plan.md not found. The researcher subagent is not yet wired in; "
-                "provide plan.md manually until the follow-up PR lands."
-            )
-        plan_content = plan_path.read_text()
+        # Phase 1: Deep Research — produce PLAN_1.md via the researcher subagent.
+        description = (self.base_dir / "description.md").read_text()
+        research_iter = 1
+        instruction = (
+            f"Research Kaggle competition '{self.slug}'. Use web_research + "
+            f"web_fetch to study the domain, prior art, and top approaches. "
+            f"Return a markdown PLAN that a developer can execute on — "
+            f"include domain context, validated hypotheses, data strategy, "
+            f"feature engineering priorities, and modeling direction.\n\n"
+            f"<competition_description>\n{description}\n</competition_description>"
+        )
+        plan_content = deep_research(instruction, self.slug, self.run_id, research_iter)
 
         external_data_listing = self._get_external_data_listing()
         print(f"External data listing: {len(external_data_listing)} chars")

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,9 @@ llm:
   leakage_review_model: "gemini-3.1-pro-preview"
   finetuned_code_api_model: "gemini-3.1-pro-preview"
 runtime:
+  # Deep Research sub-agent
+  deep_research_max_steps: 512                       # Max tool-call rounds per deep_research invocation
+  write_python_code_timeout_seconds: 300             # Per-call timeout for write_python_code subprocess
   llm_max_retries: 5
   llm_backoff_sequence: [1, 5, 10, 30, 60]
   max_developer_input_tokens: 250000

--- a/prompts/research.py
+++ b/prompts/research.py
@@ -1,0 +1,51 @@
+"""Prompts for the Deep Research sub-agent.
+
+The sub-agent has three tools: `write_python_code`, `web_research` (Exa), and
+`web_fetch` (Firecrawl). It runs a multi-step tool loop and emits a markdown
+report. Gemini's built-in `google_search` is OFF inside the sub-agent — all
+URL discovery must flow through `web_research`, and every `web_fetch` URL must
+originate from a prior tool result (no model-authored URLs).
+"""
+
+from __future__ import annotations
+
+
+def build_system() -> str:
+    return """You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
+
+=== CRITICAL: READ-ONLY MODE ===
+You may not modify, create, or delete files outside of `write_python_code`'s scratch directory. You have no Edit/Write tools — attempting any is a bug.
+
+## Available tools
+- `write_python_code(code)` — write a Python script to the researcher scratch dir and execute it in a subprocess. Full stdout/stderr is returned. Use for EDA, API probing, quick computations, dataset sniffing — anything you'd run in a notebook to validate an idea.
+- `web_research(query, num_results?)` — discover web pages for a query via Exa neural search. Returns up to `num_results` records, each with `url`, `title`, `text` (full page text, not a snippet), and `published_date`. Default 10, max 20. This is your ONLY URL-discovery path.
+- `web_fetch(url)` — fetch a single URL's main content as markdown via Firecrawl. Full content is returned; there is no truncation.
+
+## URL provenance rule (critical)
+You may only call `web_fetch(url)` with a URL that appeared in:
+(a) the `results` of a prior `web_research` call, OR
+(b) a markdown link inside a prior `web_fetch` result.
+
+Do NOT invent URLs. Do NOT reconstruct URLs from prose. Do NOT modify query strings or path segments on URLs from results. If you need a URL you do not have, run `web_research` first.
+
+## How to work
+- Start with `web_research` to map the landscape, then pick 2-5 URLs worth deep-reading.
+- `web_fetch` is expensive — skip pages whose search snippet/text already answers the question.
+- Follow inline markdown links inside a fetched page only when they clearly advance the query.
+- Prefer 3 deep fetches over 10 shallow ones.
+- Spawn parallel tool calls when they don't depend on each other.
+
+## Output contract
+When you have enough material, stop calling tools and emit your **final markdown report** as a regular message. The parent agent will save this markdown verbatim as a `PLAN.md`-style artifact, so it must be self-contained.
+
+Every concrete claim must cite a URL — either inline as `(https://...)` after the claim, or as a footnote-style `[^n]` with URLs listed at the bottom. No naked assertions.
+
+If your final message has no tool call and no text, the parent treats the research as failed — don't do that. Always emit the report, even if it's a short "I couldn't find useful material because …" summary.
+"""
+
+
+def build_user(instruction: str) -> str:
+    return f"""{instruction}
+
+Use `web_research` to discover URLs, then `web_fetch` to read the most relevant pages. Use `write_python_code` when you need to compute or probe something. Return your findings as a self-contained markdown report with URL citations for every concrete claim.
+"""

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,164 @@
+"""Tests for the Deep Research sub-agent tool helpers."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tools import research as research_module
+
+
+class _StubExa:
+    """Minimal Exa client stub: records kwargs and returns canned results."""
+
+    def __init__(self, *, api_key=None):
+        self.calls = []
+        self._next_results: list[SimpleNamespace] = []
+
+    def search_and_contents(self, query, **kwargs):
+        self.calls.append({"query": query, **kwargs})
+        return SimpleNamespace(results=self._next_results)
+
+
+class _StubFirecrawl:
+    def __init__(self, *, api_key=None):
+        self.calls = []
+        self._next_doc: SimpleNamespace | None = None
+
+    def scrape(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return self._next_doc
+
+
+class _StubJob:
+    def __init__(self, output: str):
+        self._output = output
+
+    def result(self):
+        return self._output
+
+
+@pytest.fixture
+def stubbed(monkeypatch, tmp_path):
+    exa = _StubExa()
+    fc = _StubFirecrawl()
+
+    monkeypatch.setenv("EXA_API_KEY", "test-exa")
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "test-fc")
+    monkeypatch.setattr(research_module, "Exa", lambda api_key: exa)
+    monkeypatch.setattr(research_module, "Firecrawl", lambda api_key: fc)
+
+    executed = []
+
+    def _fake_execute(filepath, timeout_seconds):
+        executed.append((filepath, timeout_seconds))
+        return _StubJob(f"ran {filepath}\n")
+
+    monkeypatch.setattr(research_module, "execute_code", _fake_execute)
+
+    research_dir = tmp_path / "research_1"
+    scripts_dir = research_dir / "scripts"
+    (research_dir / "web_research").mkdir(parents=True)
+    (research_dir / "web_fetch").mkdir(parents=True)
+    scripts_dir.mkdir(parents=True)
+
+    return SimpleNamespace(
+        exa=exa,
+        fc=fc,
+        executed=executed,
+        research_dir=research_dir,
+        scripts_dir=scripts_dir,
+    )
+
+
+def test_web_research_success_and_no_truncation(stubbed):
+    long_text = "x" * 50_000
+    stubbed.exa._next_results = [
+        SimpleNamespace(url="https://a.example/1", title="A", text=long_text, published_date="2026-01-01"),
+    ]
+    result = json.loads(research_module._tool_web_research("q", num_results=3))
+    assert len(result["results"]) == 1
+    assert result["results"][0]["text"] == long_text          # no truncation
+    assert stubbed.exa.calls[0]["num_results"] == 3           # passed through, no clamp
+    assert stubbed.exa.calls[0]["type"] == "auto"
+    assert stubbed.exa.calls[0]["text"] is True
+
+
+def test_web_research_empty_returns_error(stubbed):
+    stubbed.exa._next_results = []
+    result = json.loads(research_module._tool_web_research("nothing", num_results=None))
+    assert "error" in result
+    assert "num_results" not in stubbed.exa.calls[0]          # omitted when None
+
+
+def test_web_fetch_success_and_no_truncation(stubbed):
+    long_md = "# heading\n" + ("para\n" * 10_000)
+    stubbed.fc._next_doc = SimpleNamespace(
+        markdown=long_md, metadata=SimpleNamespace(title="Title")
+    )
+    result = json.loads(research_module._tool_web_fetch("https://e.example"))
+    assert result["markdown"] == long_md                      # no truncation
+    assert stubbed.fc.calls[0]["only_main_content"] is True
+
+
+def test_write_python_code_writes_and_executes(stubbed):
+    result = json.loads(
+        research_module._tool_write_python_code("print('hi')", 5, stubbed.scripts_dir)
+    )
+    script_path = stubbed.scripts_dir / "5.py"
+    assert script_path.exists()
+    assert "print('hi')" in script_path.read_text()
+    assert "ran" in result["output"]
+    assert stubbed.executed[0][1] == research_module._WRITE_PYTHON_CODE_TIMEOUT_SECONDS
+
+
+def test_execute_tool_call_dispatches_and_writes_markdown_records(stubbed):
+    stubbed.exa._next_results = [
+        SimpleNamespace(url="https://a.example", title="A", text="body-a", published_date=None),
+    ]
+    stubbed.fc._next_doc = SimpleNamespace(
+        markdown="# hello\nworld", metadata=SimpleNamespace(title="H")
+    )
+
+    state = {
+        "research_dir": stubbed.research_dir,
+        "scripts_dir": stubbed.scripts_dir,
+        "tool_seq": {},
+    }
+
+    # web_research
+    item = SimpleNamespace(name="web_research", args={"query": "foo", "num_results": 2})
+    research_module._execute_tool_call(item, state)
+    wr_record = (stubbed.research_dir / "web_research" / "1.md").read_text()
+    assert "# web_research #1" in wr_record
+    assert "https://a.example" in wr_record
+    assert "body-a" in wr_record
+
+    # web_fetch
+    item = SimpleNamespace(name="web_fetch", args={"url": "https://e.example"})
+    research_module._execute_tool_call(item, state)
+    wf_record = (stubbed.research_dir / "web_fetch" / "1.md").read_text()
+    assert "# web_fetch #1" in wf_record
+    assert "# hello\nworld" in wf_record
+
+    # write_python_code — no markdown record, but script IS written
+    item = SimpleNamespace(name="write_python_code", args={"code": "x=1"})
+    research_module._execute_tool_call(item, state)
+    assert (stubbed.scripts_dir / "1.py").exists()
+    assert not (stubbed.research_dir / "write_python_code").exists()
+
+    # unknown tool raises
+    with pytest.raises(ValueError, match="Unknown tool"):
+        research_module._execute_tool_call(
+            SimpleNamespace(name="nope", args={}), state
+        )
+
+
+def test_render_tool_record_markdown_error_path():
+    rendered = research_module._render_tool_record_markdown(
+        "web_research", 2, {"query": "q"}, json.dumps({"error": "exa down"})
+    )
+    assert "# web_research #2" in rendered
+    assert "**ERROR:** exa down" in rendered

--- a/tools/research.py
+++ b/tools/research.py
@@ -1,0 +1,308 @@
+"""Deep Research sub-agent.
+
+A sub-agent that the main (or orchestrator) agent can call with a research
+instruction. It runs a multi-step tool loop over three tools — `web_research`
+(Exa discovery), `web_fetch` (Firecrawl scrape), and `write_python_code`
+(subprocess exec) — and emits a markdown report. Gemini's built-in
+`google_search` is disabled inside the sub-agent so that every URL the LLM
+dereferences is traceable back to a prior tool result (no invented URLs).
+
+No truncation is applied to `web_research` / `web_fetch` outputs — full content
+flows back to the LLM so the research can go as deep as the step budget allows.
+
+Per-invocation layout (owned by this module):
+
+    task/<slug>/<run_id>/research_<research_iter>/
+    ├── scripts/       # executed Python scripts (re-runnable standalone)
+    │   └── <seq>.py
+    ├── web_research/  # per-call audit records for web_research
+    │   └── <seq>.md
+    ├── web_fetch/     # per-call audit records for web_fetch
+    │   └── <seq>.md
+    └── PLAN_<research_iter>.md   # final markdown report
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import weave
+from dotenv import load_dotenv
+from exa_py import Exa
+from firecrawl import Firecrawl
+from google.genai import types
+
+from project_config import get_config
+from prompts.research import build_system, build_user
+from tools.developer import _build_resource_header, execute_code
+from tools.helpers import call_llm
+from utils.llm_utils import append_message, get_deep_research_tools
+
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+_CONFIG = get_config()
+_LLM_CFG = _CONFIG["llm"]
+_RUNTIME_CFG = _CONFIG["runtime"]
+_PATH_CFG = _CONFIG["paths"]
+
+_TASK_ROOT = Path(_PATH_CFG["task_root"])
+_DEEP_RESEARCH_LLM_MODEL = _LLM_CFG["developer_tool_model"]
+_DEEP_RESEARCH_MAX_STEPS = _RUNTIME_CFG["deep_research_max_steps"]
+_WRITE_PYTHON_CODE_TIMEOUT_SECONDS = _RUNTIME_CFG["write_python_code_timeout_seconds"]
+
+
+# ---------------------------------------------------------------------------
+# Inner tool implementations
+# ---------------------------------------------------------------------------
+
+
+def _tool_web_research(query: str, num_results: int | None) -> str:
+    """Exa neural search. Returns full text for each result — no truncation."""
+    logger.info("web_research query=%r num_results=%s", query, num_results)
+
+    exa_client = Exa(api_key=os.environ["EXA_API_KEY"])
+    search_kwargs = {"type": "auto", "text": True}
+    if num_results is not None:
+        search_kwargs["num_results"] = num_results
+
+    try:
+        search_response = exa_client.search_and_contents(query, **search_kwargs)
+    except Exception as exc:
+        logger.exception("Exa search_and_contents failed")
+        return json.dumps({"error": f"exa search failed: {exc}"})
+
+    results = [
+        {
+            "url": r.url,
+            "title": r.title,
+            "text": r.text or "",
+            "published_date": r.published_date,
+        }
+        for r in search_response.results
+    ]
+    if not results:
+        return json.dumps({"error": "no results — try reformulating the query"})
+
+    return json.dumps({"results": results})
+
+
+def _tool_web_fetch(url: str) -> str:
+    """Firecrawl scrape → markdown. Full content, no truncation."""
+    logger.info("web_fetch url=%s", url)
+
+    firecrawl_client = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+    try:
+        doc = firecrawl_client.scrape(
+            url, only_main_content=True, formats=["markdown"]
+        )
+    except Exception as exc:
+        logger.exception("Firecrawl scrape failed for %s", url)
+        return json.dumps({"error": f"firecrawl scrape failed: {exc}"})
+
+    title = doc.metadata.title if doc.metadata is not None else None
+    markdown = doc.markdown or ""
+
+    return json.dumps({"url": url, "title": title or url, "markdown": markdown})
+
+
+def _tool_write_python_code(code: str, seq: int, scripts_dir: Path) -> str:
+    """Save + exec a Python script in the scripts dir. Return full stdout/stderr."""
+    script_path = scripts_dir / f"{seq}.py"
+    script_path.write_text(_build_resource_header(None, None) + code)
+    logger.info("write_python_code seq=%d path=%s", seq, script_path)
+
+    try:
+        job = execute_code(
+            str(script_path), timeout_seconds=_WRITE_PYTHON_CODE_TIMEOUT_SECONDS
+        )
+        output = job.result()
+    except Exception as exc:
+        logger.exception("write_python_code execution failed")
+        return json.dumps({"error": f"execution failed: {exc}"})
+
+    return json.dumps({"output": output})
+
+
+def _render_tool_record_markdown(
+    tool_name: str, seq: int, args: dict, result_json: str
+) -> str:
+    """Render one tool call (args + result) as a self-contained markdown audit note."""
+    result = json.loads(result_json)
+    header = f"# {tool_name} #{seq}\n\n"
+
+    if "error" in result:
+        return header + f"**ERROR:** {result['error']}\n"
+
+    if tool_name == "web_research":
+        lines = [header, f"**Query:** {args['query']}\n"]
+        if args.get("num_results") is not None:
+            lines.append(f"**Requested num_results:** {args['num_results']}\n")
+        lines.append(f"**Num results returned:** {len(result['results'])}\n\n---\n\n")
+        for idx, item in enumerate(result["results"], start=1):
+            lines.append(f"## Result {idx}: {item['title'] or '(no title)'}\n\n")
+            lines.append(f"- **URL:** {item['url']}\n")
+            if item.get("published_date"):
+                lines.append(f"- **Published:** {item['published_date']}\n")
+            lines.append(f"\n{item['text']}\n\n---\n\n")
+        return "".join(lines)
+
+    if tool_name == "web_fetch":
+        return (
+            header
+            + f"**URL:** {result['url']}\n"
+            + f"**Title:** {result['title']}\n\n"
+            + "---\n\n"
+            + f"{result['markdown']}\n"
+        )
+
+    raise ValueError(f"Unknown tool_name for record rendering: {tool_name}")
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _execute_tool_call(item, state: dict) -> str:
+    args = dict(item.args)
+    tool_name = item.name
+
+    tool_seq = state["tool_seq"].get(tool_name, 0) + 1
+    state["tool_seq"][tool_name] = tool_seq
+
+    if tool_name == "web_research":
+        result_json = _tool_web_research(args["query"], args.get("num_results"))
+    elif tool_name == "web_fetch":
+        result_json = _tool_web_fetch(args["url"])
+    elif tool_name == "write_python_code":
+        result_json = _tool_write_python_code(
+            args["code"], tool_seq, state["scripts_dir"]
+        )
+    else:
+        raise ValueError(f"Unknown tool: {tool_name}")
+
+    if tool_name in ("web_research", "web_fetch"):
+        record_path = state["research_dir"] / tool_name / f"{tool_seq}.md"
+        record_path.write_text(
+            _render_tool_record_markdown(tool_name, tool_seq, args, result_json)
+        )
+
+    return result_json
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+@weave.op()
+def deep_research(instruction: str, slug: str, run_id: str, research_iter: int) -> str:
+    """Run the Deep Research sub-agent and return a markdown report.
+
+    Creates `task/<slug>/<run_id>/research_<research_iter>/`, runs the tool
+    loop, and persists the final markdown as `PLAN_<research_iter>.md` inside
+    that directory. The markdown is also returned to the caller.
+
+    Args:
+        instruction: Free-form research instruction — as long as needed.
+        slug: Competition slug (maps to `task/<slug>/`).
+        run_id: Orchestrator run identifier (timestamp dir under task/<slug>/).
+        research_iter: Per-caller invocation counter — starts at 1, increments
+            each time the caller invokes deep_research for the same run.
+
+    Returns:
+        Free-form markdown report with URL citations.
+    """
+    research_dir = _TASK_ROOT / slug / run_id / f"research_{research_iter}"
+    scripts_dir = research_dir / "scripts"
+    web_research_dir = research_dir / "web_research"
+    web_fetch_dir = research_dir / "web_fetch"
+    for d in (scripts_dir, web_research_dir, web_fetch_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    logger.info(
+        "deep_research slug=%s run_id=%s iter=%d dir=%s instruction=%r",
+        slug,
+        run_id,
+        research_iter,
+        research_dir,
+        instruction,
+    )
+
+    system_prompt = build_system()
+    user_prompt = build_user(instruction)
+    tools = get_deep_research_tools()
+    state: dict = {
+        "research_dir": research_dir,
+        "scripts_dir": scripts_dir,
+        "tool_seq": {},
+    }
+    input_list = [append_message("user", user_prompt)]
+
+    markdown = ""
+    for step in range(_DEEP_RESEARCH_MAX_STEPS):
+        is_last_step = step == _DEEP_RESEARCH_MAX_STEPS - 1
+        logger.info("deep_research step %d/%d", step + 1, _DEEP_RESEARCH_MAX_STEPS)
+
+        response = call_llm(
+            model=_DEEP_RESEARCH_LLM_MODEL,
+            system_instruction=system_prompt,
+            function_declarations=tools if not is_last_step else [],
+            messages=input_list,
+            enable_google_search=False,
+        )
+
+        parts = response.candidates[0].content.parts
+        has_function_calls = any(
+            part.function_call
+            for part in parts
+            if hasattr(part, "function_call")
+        )
+
+        if not has_function_calls:
+            logger.info("deep_research completed at step %d", step + 1)
+            markdown = response.text or ""
+            break
+
+        function_responses = []
+        for part in parts:
+            if hasattr(part, "function_call") and part.function_call:
+                tool_result_str = _execute_tool_call(part.function_call, state)
+                function_responses.append(
+                    types.Part.from_function_response(
+                        name=part.function_call.name,
+                        response={"result": tool_result_str},
+                    )
+                )
+
+        input_list.append(response.candidates[0].content)
+        if function_responses:
+            input_list.append(
+                types.Content(role="function", parts=function_responses)
+            )
+    else:
+        logger.warning(
+            "deep_research exhausted %d steps — forcing final report", _DEEP_RESEARCH_MAX_STEPS
+        )
+        response = call_llm(
+            model=_DEEP_RESEARCH_LLM_MODEL,
+            system_instruction=system_prompt
+            + "\n\nReturn your final markdown report now, based on everything you have gathered.",
+            messages=input_list,
+            enable_google_search=False,
+        )
+        markdown = response.text or ""
+
+    plan_path = research_dir / f"PLAN_{research_iter}.md"
+    plan_path.write_text(markdown)
+    logger.info("deep_research wrote %s (%d chars)", plan_path, len(markdown))
+
+    return markdown

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -140,6 +140,81 @@ def get_monitor_tools():
 
 
 # ---------------------------------------------------------------------------
+# Deep Research tools (web_research + web_fetch + write_python_code)
+# ---------------------------------------------------------------------------
+
+
+def get_deep_research_tools():
+    """Inner tools available to the Deep Research sub-agent."""
+    return [
+        types.FunctionDeclaration(
+            name="web_research",
+            description=(
+                "Discover web pages for a query via Exa neural search. "
+                "Returns a list of results, each with url, title, full page text, "
+                "and published_date — not a snippet, the whole text. This is the "
+                "ONLY way to discover URLs; never guess or reconstruct URLs."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language search query.",
+                    },
+                    "num_results": {
+                        "type": "integer",
+                        "description": (
+                            "Optional number of results to return. Omit to use "
+                            "the Exa default."
+                        ),
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="web_fetch",
+            description=(
+                "Fetch a single URL's main content as markdown via Firecrawl. "
+                "Full page content is returned — no truncation. Only call with "
+                "URLs you got from a prior `web_research` result or from a "
+                "markdown link inside a prior `web_fetch` result."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "Absolute URL to fetch.",
+                    },
+                },
+                "required": ["url"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="write_python_code",
+            description=(
+                "Write a Python script to the research scripts dir and execute "
+                "it in a subprocess. Full stdout/stderr is returned. Use for "
+                "EDA, API probing, quick computations — anything you'd run in "
+                "a notebook to validate an idea."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "Complete Python source to execute.",
+                    },
+                },
+                "required": ["code"],
+            },
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Explore tools (read-only, scoped to runtime.explore_allowed_roots)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- New `deep_research(query, slug, research_iter)` sub-agent (`tools/research.py`) — analogous to `explore_codebase` but web-facing. Inner toolkit:
  - `web_research(query, num_results?)` — Exa neural search, full text per result, no truncation.
  - `web_fetch(url)` — Firecrawl markdown scrape with `only_main_content=True`, full content, no truncation.
  - `write_python_code(code)` — save-to-scratch + subprocess execute, full stdout/stderr returned.
- Gemini's built-in `google_search` is **off** inside the sub-agent so all URL discovery must flow through `web_research` — fixes the URL hallucination problem from issue #141.
- Orchestrator Phase 1 now calls `deep_research` and uses the returned markdown as the `plan_content` string it feeds downstream developer agents.
- Per-invocation filesystem layout under `task/<slug>/research_<n>/`:
  - `scripts/<seq>.py` — executable Python artifacts.
  - `web_research/<seq>.md` + `web_fetch/<seq>.md` — human-readable audit records (args + result) per tool call.
  - `PLAN_<n>.md` — final markdown report (also returned to caller).
- Config knobs added to `config.yaml` under `runtime:`: `deep_research_max_steps: 512`, `write_python_code_timeout_seconds: 300`.
- Tool schemas live in a new `utils/llm_utils.py::get_deep_research_tools()`.

## Files
- New: `tools/research.py`, `prompts/research.py`, `tests/test_research.py`.
- Modified: `agents/orchestrator.py` (Phase 1 calls `deep_research`), `utils/llm_utils.py` (+ `get_deep_research_tools`), `config.yaml` (+ new knobs).

## Test plan
- [x] `pytest tests/test_research.py -q` — 6 tests pass (web_research success + no-truncation, empty-results → error JSON, web_fetch full-content no-truncation, write_python_code writes+executes, `_execute_tool_call` dispatches + writes markdown records + raises on unknown tool, error-path markdown rendering).
- [x] `pytest tests/ -q` — 60 total pass, no regressions.
- [ ] End-to-end orchestrator run against a real competition slug — pending.
- [ ] CI: unit tests.