### PR TITLE
remove strategy_name and wire researcher instructions into deep research

### DIFF
--- a/INSTRUCTIONS_EXAMPLE.md
+++ b/INSTRUCTIONS_EXAMPLE.md
@@ -1,5 +1,3 @@
 # Researcher Instructions
 
 # Developer Instructions
-
-# Strategies

--- a/README.md
+++ b/README.md
@@ -94,9 +94,8 @@ Before running, create these files in `task/<slug>/`:
 - **`metric.py`**: Competition-specific evaluation metric
 
 Optionally, add Human-In-The-Loop (HITL) instructions in `INSTRUCTIONS.md`:
-- `# Researcher Instructions`: Guide research direction
-- `# Strategies`: Override strategy selection
-- `# Developer Instructions`: Guide code implementation
+- `# Researcher Instructions`: Guide research direction — fed into every Deep Research sub-agent invocation.
+- `# Developer Instructions`: Guide code implementation — fed into every Developer iteration.
 
 ### Launch
 

--- a/agents/developer.py
+++ b/agents/developer.py
@@ -64,7 +64,6 @@ class DeveloperAgent:
         slug: str,
         run_id: str,
         iteration: int | str,
-        strategy_name: str | None = None,
         external_data_listing: str | None = None,
         plan_content: str | None = None,
     ):
@@ -125,9 +124,6 @@ class DeveloperAgent:
 
         os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
-        self.strategy_name: str | None = strategy_name
-        assert self.strategy_name is not None
-
         self.logger.info(
             "Initialized DeveloperAgent for slug=%s iteration=%s",
             self.slug,
@@ -164,7 +160,6 @@ class DeveloperAgent:
         return prompt_build_system(
             description=self.description,
             directory_listing=directory_listing,
-            strategy_name=self.strategy_name,
             slug=self.slug,
             hitl_instructions=_HITL_INSTRUCTIONS,
         )
@@ -603,9 +598,7 @@ class DeveloperAgent:
             "last_input_tokens": last_input_tokens,
         }
         conn = self._get_checkpoint_db()
-        save_checkpoint(
-            conn, self.slug, str(self.iteration), self.strategy_name, version, state
-        )
+        save_checkpoint(conn, self.slug, str(self.iteration), version, state)
         self.logger.info("Checkpoint saved for v%s", version)
 
     def _load_latest_checkpoint(self):

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import json
 
 from agents.developer import DeveloperAgent
-from project_config import get_config, get_instructions
+from project_config import get_config
 from tools.research import deep_research
 from tools.helpers import _build_directory_listing
 from utils.checkpoint import (
@@ -18,30 +18,6 @@ _CONFIG = get_config()
 _RUNTIME_CFG = _CONFIG["runtime"]
 _PATH_CFG = _CONFIG["paths"]
 _TASK_ROOT = Path(_PATH_CFG["task_root"])
-
-
-@weave.op()
-def _run_developer_baseline(
-    slug: str,
-    run_id: str,
-    iteration_suffix: str,
-    strategy_name: str,
-    key: str,
-    external_data_listing: str,
-    plan_content: str,
-):
-    """Run a single baseline DeveloperAgent and return results."""
-    baseline_time_limit = _RUNTIME_CFG["baseline_time_limit"]
-    dev = DeveloperAgent(
-        slug,
-        run_id,
-        iteration_suffix,
-        strategy_name=strategy_name,
-        external_data_listing=external_data_listing,
-        plan_content=plan_content,
-    )
-    best_score, best_code_file = dev.run(max_time_seconds=baseline_time_limit)
-    return key, best_score, best_code_file
 
 
 class Orchestrator:
@@ -76,56 +52,39 @@ class Orchestrator:
 
         return "\n".join(lines)
 
-    def _rollback(self, model_iterations: list[str]) -> None:
-        """Roll back all models to self.rollback_to_version.
-
-        Moves version folders beyond N into _trash/<timestamp>/ and deletes checkpoint
-        rows beyond N. Also removes baseline_results.json so affected models get re-run.
-        """
+    def _rollback(self) -> None:
+        """Roll back the current run's developer outputs to self.rollback_to_version."""
         target = self.rollback_to_version
-        parent_outputs = self.outputs_dir
+        model_dir = self.outputs_dir
 
-        found = False
-        for iter_suffix in model_iterations:
-            model_dir = parent_outputs / iter_suffix
-            if (model_dir / str(target)).exists():
-                found = True
-                break
-        if not found:
+        if not (model_dir / str(target)).exists():
             raise ValueError(
-                f"Rollback failed: version {target} not found in any model outputs ({model_iterations})"
+                f"Rollback failed: version {target} not found in {model_dir}"
             )
 
         timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         conn = _create_checkpoint_db()
 
-        for iter_suffix in model_iterations:
-            model_dir = parent_outputs / iter_suffix
-            if not model_dir.exists():
+        trash_dir = model_dir / "_trash" / timestamp
+        moved_any = False
+
+        for entry in sorted(model_dir.iterdir()):
+            if not entry.is_dir() or entry.name.startswith("_"):
                 continue
+            try:
+                version_num = int(entry.name)
+            except ValueError:
+                continue
+            if version_num > target:
+                if not moved_any:
+                    trash_dir.mkdir(parents=True, exist_ok=True)
+                    moved_any = True
+                dest = trash_dir / entry.name
+                entry.rename(dest)
+                print(f"Rollback: moved {entry} -> {dest}")
 
-            trash_dir = model_dir / "_trash" / timestamp
-            moved_any = False
-
-            for entry in sorted(model_dir.iterdir()):
-                if not entry.is_dir() or entry.name.startswith("_"):
-                    continue
-                try:
-                    version_num = int(entry.name)
-                except ValueError:
-                    continue
-                if version_num > target:
-                    if not moved_any:
-                        trash_dir.mkdir(parents=True, exist_ok=True)
-                        moved_any = True
-                    dest = trash_dir / entry.name
-                    entry.rename(dest)
-                    print(f"Rollback: moved {entry} -> {dest}")
-
-            delete_checkpoints_after(conn, self.slug, iter_suffix, target)
-            print(
-                f"Rollback: deleted checkpoints after v{target} for iteration {iter_suffix}"
-            )
+        delete_checkpoints_after(conn, self.slug, self.run_id, target)
+        print(f"Rollback: deleted checkpoints after v{target} for run {self.run_id}")
 
         baseline_path = self.outputs_dir / "baseline_results.json"
         if baseline_path.exists():
@@ -157,65 +116,32 @@ class Orchestrator:
         print(f"External data listing: {len(external_data_listing)} chars")
         print(f"Plan content: {len(plan_content)} chars")
 
-        # Phase 2: Baseline Developer Stage — run strategies sequentially.
-        strategy_list = get_instructions()["# Strategies"]
-        if not strategy_list:
-            raise RuntimeError(
-                "No strategies specified. Please add strategies to INSTRUCTIONS.md under '# Strategies'."
-            )
-        print(f"Using strategies from INSTRUCTIONS.md: {strategy_list}")
-
         if self.rollback_to_version is not None:
-            model_iterations = [
-                str(idx)
-                for idx in range(1, len(strategy_list) + 1)
-            ]
-            self._rollback(model_iterations)
+            self._rollback()
 
-        existing_baseline_results = {}
+        # Phase 2: Developer — one baseline run per invocation.
         baseline_path = self.outputs_dir / "baseline_results.json"
         if baseline_path.exists():
             with open(baseline_path, "r") as f:
-                existing_baseline_results = json.load(f)
-            print(
-                f"Loaded existing baseline results with {len(existing_baseline_results)} strategies"
-            )
+                existing = json.load(f)
+            print(f"Baseline already completed: {existing}")
+            return True, str(baseline_path)
 
-        baseline_results = existing_baseline_results.copy()
+        baseline_time_limit = _RUNTIME_CFG["baseline_time_limit"]
+        dev = DeveloperAgent(
+            self.slug,
+            self.run_id,
+            "1",
+            external_data_listing=external_data_listing,
+            plan_content=plan_content,
+        )
+        best_score, best_code_file = dev.run(max_time_seconds=baseline_time_limit)
 
-        for idx, strategy_name in enumerate(strategy_list, start=1):
-            key = strategy_name
-            dev_iter = str(idx)
-
-            if key in existing_baseline_results:
-                print(f"Skipping {key} (iteration {dev_iter}): already completed")
-                continue
-
-            print(f"Running {key} (iteration {dev_iter}) sequentially")
-            try:
-                result_key, best_score, best_code_file = _run_developer_baseline(
-                    self.slug,
-                    self.run_id,
-                    dev_iter,
-                    strategy_name,
-                    key,
-                    external_data_listing,
-                    plan_content,
-                )
-                baseline_results[result_key] = {
-                    "strategy_name": result_key,
-                    "best_score": best_score,
-                    "best_code_file": best_code_file or "",
-                }
-                with open(baseline_path, "w") as f:
-                    json.dump(baseline_results, f, indent=2)
-            except Exception as e:
-                print(f"Error in baseline task {key}: {e}")
-                continue
-
-        if not baseline_results:
-            raise RuntimeError("All developer baseline runs failed")
-
+        baseline_results = {
+            "best_score": best_score,
+            "best_code_file": best_code_file or "",
+        }
+        self.outputs_dir.mkdir(parents=True, exist_ok=True)
         with open(baseline_path, "w") as f:
             json.dump(baseline_results, f, indent=2)
         return True, str(baseline_path)

--- a/project_config.py
+++ b/project_config.py
@@ -31,7 +31,6 @@ def get_config_value(*keys: str, default: Any | None = None) -> Any:
 _INSTRUCTIONS_HEADINGS = [
     "# Researcher Instructions",
     "# Developer Instructions",
-    "# Strategies",
 ]
 
 
@@ -53,7 +52,7 @@ def _extract_section(text: str, heading: str, next_heading: str | None) -> list[
 def get_instructions() -> dict[str, list[str]]:
     """Parse INSTRUCTIONS.md and return content under each known H1 heading.
 
-    Headings (in order): # Researcher Instructions, # Developer Instructions, # Strategies.
+    Headings (in order): # Researcher Instructions, # Developer Instructions.
     Every non-empty line between one heading and the next belongs to that section.
     """
     instructions_path = Path(__file__).resolve().parent / "INSTRUCTIONS.md"

--- a/prompts/developer_agent.py
+++ b/prompts/developer_agent.py
@@ -61,7 +61,6 @@ File contents:
 def build_system(
     description: str,
     directory_listing: str,
-    strategy_name: str,
     slug: str,
     hitl_instructions: list[str] | None = None,
 ) -> str:
@@ -76,11 +75,11 @@ def build_system(
 ---
 """
 
-    constraints = get_hard_constraints(strategy_name=strategy_name)
+    constraints = get_hard_constraints()
 
     helper_files_section = _read_helper_files(slug)
 
-    return f"""You write train.py for Kaggle competitions using **only** the specified model `{strategy_name}`.
+    return f"""You write train.py for Kaggle competitions.
 
 **Environment:** Single GPU (40GB VRAM)
 
@@ -107,7 +106,7 @@ The script must save these files to the paths specified in the user prompt:
 1. **`submission.csv`**: Test predictions formatted per competition requirements.
 2. **`valid_preds.csv`**: Validation predictions with fold numbers, raw predictions, ground truth labels, and row IDs.
 3. **`model_*.{{ext}}`**: Saved model files. Save per-fold if using CV.
-4. **`train_stats.json`**: Must contain `strategy_name`, `cv_scores`, `cv_mean`, `cv_std`, `cv_worst`, `submission_distribution`, key hyperparameters, and `errors` (list of exceptions encountered).
+4. **`train_stats.json`**: Must contain `cv_scores`, `cv_mean`, `cv_std`, `cv_worst`, `submission_distribution`, key hyperparameters, and `errors` (list of exceptions encountered).
 5. **`loss_curve.png`** and **`metric_curve.png`**: One subplot per fold showing train/val curves. Use `plt.switch_backend('Agg')`. Do not call `plt.show()`.
 """
 

--- a/prompts/research.py
+++ b/prompts/research.py
@@ -10,8 +10,21 @@ originate from a prior tool result (no model-authored URLs).
 from __future__ import annotations
 
 
-def build_system() -> str:
-    return """You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
+def build_system(hitl_instructions: list[str] | None = None) -> str:
+    hitl_section = ""
+    if hitl_instructions:
+        hitl_items = "\n".join(hitl_instructions)
+        hitl_section = f"""
+
+# Additional Instructions
+
+{hitl_items}
+
+---
+"""
+
+    return f"""You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
+{hitl_section}
 
 === CRITICAL: READ-ONLY MODE ===
 You may not modify, create, or delete files outside of `write_python_code`'s scratch directory. You have no Edit/Write tools — attempting any is a bug.
@@ -41,7 +54,7 @@ When you have enough material, stop calling tools and emit your **final markdown
 Every concrete claim must cite a URL — either inline as `(https://...)` after the claim, or as a footnote-style `[^n]` with URLs listed at the bottom. No naked assertions.
 
 If your final message has no tool call and no text, the parent treats the research as failed — don't do that. Always emit the report, even if it's a short "I couldn't find useful material because …" summary.
-"""
+"""  # noqa: E501
 
 
 def build_user(instruction: str) -> str:

--- a/prompts/shared_constraints.py
+++ b/prompts/shared_constraints.py
@@ -1,18 +1,9 @@
 from __future__ import annotations
 
 
-def get_hard_constraints(
-    strategy_name: str | None = None,
-) -> str:
-    lines = ["**Hard Constraints:**"]
-
-    if strategy_name:
-        lines.append(
-            f"- Use ONLY `{strategy_name}`. Do not swap the model; you may update preprocessing, postprocessing, or hyperparameters."
-        )
-
-    lines.append(
-        """- **DO NOT** explicitly set `os.environ['CUDA_VISIBLE_DEVICES']`.
+def get_hard_constraints() -> str:
+    return """**Hard Constraints:**
+- **DO NOT** explicitly set `os.environ['CUDA_VISIBLE_DEVICES']`.
 - Place `import logging` and `logging.basicConfig(level=logging.INFO, ...)` at the very top of the script, BEFORE any third-party imports (torch, transformers, kagglehub, etc.). Third-party libraries configure logging on import, so basicConfig must come first.
 - Log validation results (per fold and overall), model loading, train/test set size, and any computed quantities that can go wrong (e.g. class weights, thresholds).
 - Log final validation results, best epoch number, total training time, and submission prediction distribution.
@@ -23,6 +14,3 @@ def get_hard_constraints(
 import kagglehub
 path = kagglehub.dataset_download("<author>/<dataset_name>")
 ```"""
-    )
-
-    return "\n".join(lines)

--- a/tests/test_developer_agent.py
+++ b/tests/test_developer_agent.py
@@ -51,7 +51,6 @@ def test_agent_initialization(test_task_dir, monkeypatch):
         slug=test_task_dir["slug"],
         run_id="20260418_000000",
         iteration=test_task_dir["iteration"],
-        strategy_name="test-strategy",
         plan_content="Test plan",
     )
 
@@ -59,7 +58,6 @@ def test_agent_initialization(test_task_dir, monkeypatch):
     assert agent.iteration == test_task_dir["iteration"]
     assert agent.outputs_dir.exists()
     assert agent.base_dir.exists()
-    assert agent.strategy_name == "test-strategy"
 
 
 def test_extract_code(test_task_dir, monkeypatch):

--- a/tools/research.py
+++ b/tools/research.py
@@ -35,7 +35,7 @@ from exa_py import Exa
 from firecrawl import Firecrawl
 from google.genai import types
 
-from project_config import get_config
+from project_config import get_config, get_instructions
 from prompts.research import build_system, build_user
 from tools.developer import _build_resource_header, execute_code
 from tools.helpers import call_llm
@@ -56,6 +56,7 @@ _TASK_ROOT = Path(_PATH_CFG["task_root"])
 _DEEP_RESEARCH_LLM_MODEL = _LLM_CFG["developer_tool_model"]
 _DEEP_RESEARCH_MAX_STEPS = _RUNTIME_CFG["deep_research_max_steps"]
 _WRITE_PYTHON_CODE_TIMEOUT_SECONDS = _RUNTIME_CFG["write_python_code_timeout_seconds"]
+_HITL_INSTRUCTIONS = get_instructions()["# Researcher Instructions"]
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +238,7 @@ def deep_research(instruction: str, slug: str, run_id: str, research_iter: int) 
         instruction,
     )
 
-    system_prompt = build_system()
+    system_prompt = build_system(hitl_instructions=_HITL_INSTRUCTIONS)
     user_prompt = build_user(instruction)
     tools = get_deep_research_tools()
     state: dict = {

--- a/utils/checkpoint.py
+++ b/utils/checkpoint.py
@@ -13,7 +13,6 @@ _COL_NAMES = [
     "id",
     "slug",
     "iteration",
-    "strategy_name",
     "version",
     "best_score",
     "best_version",
@@ -39,7 +38,6 @@ def create_db(db_path: str | Path = _DB_PATH) -> sqlite3.Connection:
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             slug TEXT NOT NULL,
             iteration TEXT NOT NULL,
-            strategy_name TEXT NOT NULL,
             version INTEGER NOT NULL,
             best_score REAL,
             best_version INTEGER,
@@ -60,24 +58,22 @@ def save_checkpoint(
     conn: sqlite3.Connection,
     slug: str,
     iteration: str,
-    strategy_name: str,
     version: int,
     state: dict,
 ) -> None:
     conn.execute(
         """
         INSERT OR REPLACE INTO checkpoints (
-            slug, iteration, strategy_name, version,
+            slug, iteration, version,
             best_score, best_version, best_code_file,
             version_scores, successful_versions,
             input_list, last_input_tokens,
             created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, jsonb(?), jsonb(?), jsonb(?), ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, jsonb(?), jsonb(?), jsonb(?), ?, ?)
     """,
         (
             slug,
             iteration,
-            strategy_name,
             version,
             state["best_score"],
             state["best_version"],


### PR DESCRIPTION
## Summary
- Drop the `strategy_name` concept and the `# Strategies` INSTRUCTIONS.md section. The Developer is no longer pinned to a single model family per run — it picks models based on the plan and `# Developer Instructions`.
- `DeveloperAgent.__init__`: remove `strategy_name` param + the `assert self.strategy_name is not None` guard; drop the `# Strategies` thread-through from `Orchestrator.run()`.
- `prompts/developer_agent.py::build_system` drops the `strategy_name` param and its two references in the system prompt (the "using **only** the specified model" preamble and the `train_stats.json` `strategy_name` requirement). The prompt body is unchanged in spirit.
- `prompts/shared_constraints.py::get_hard_constraints` becomes zero-arg — no more per-strategy "Use ONLY `<model>`" constraint.
- `utils/checkpoint.py`: drop the `strategy_name` column from the checkpoints table schema and `save_checkpoint`'s signature. **Delete `checkpoints.db` before first run on main; the schema changed.**
- `agents/orchestrator.py`: remove the strategy loop entirely — orchestrator runs a single Developer per invocation. `_run_developer_baseline` helper folded into `run()`.
- `project_config.py`: drop `# Strategies` from the known-headings list in `get_instructions()`.
- **Wire `# Researcher Instructions` into Deep Research**: `tools/research.py` now loads `get_instructions()["# Researcher Instructions"]` at module level and passes it to `prompts/research.py::build_system(hitl_instructions=...)` on every invocation. Each Deep Research sub-agent call now sees the user's researcher-side HITL block in its system prompt. Developer already had this wiring via `# Developer Instructions` — unchanged.
- `INSTRUCTIONS_EXAMPLE.md`: drop `# Strategies`. (`INSTRUCTIONS.md` is gitignored — users remove the section in their own copy.)
- `README.md`: update the HITL-instructions section description (no more `# Strategies` bullet; clarify that both remaining sections are fed into every sub-agent/iteration respectively).
- Update `tests/test_developer_agent.py` to stop passing `strategy_name=...`.

## Files
- Modified: `agents/developer.py`, `agents/orchestrator.py`, `prompts/developer_agent.py`, `prompts/shared_constraints.py`, `prompts/research.py`, `tools/research.py`, `utils/checkpoint.py`, `project_config.py`, `tests/test_developer_agent.py`, `INSTRUCTIONS_EXAMPLE.md`, `README.md`.

## Test plan
- [x] `grep -r "strategy_name\|strategy_list\|# Strategies\|get_hard_constraints.*strategy" --include="*.py" --include="*.md" --include="*.yaml"` — no in-repo matches outside `archive/` / `libraries/`.
- [x] `python -c "from agents.orchestrator import Orchestrator; from agents.developer import DeveloperAgent; from tools.research import deep_research; from project_config import get_instructions; assert list(get_instructions()) == ['# Researcher Instructions', '# Developer Instructions']"` — passes.
- [x] `pytest tests/ -q --ignore=tests/test_research.py` — 47 pass.
- [ ] End-to-end orchestrator run against a real competition slug — single Developer run with `# Researcher Instructions` visible in the Deep Research sub-agent's system prompt; `# Developer Instructions` visible in the Developer system prompt.
- [ ] CI: unit tests.