### PR TITLE
introduce task/<slug>/<run_id>/ timestamped run container

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -60,15 +60,14 @@ _HITL_INSTRUCTIONS = get_instructions()["# Developer Instructions"]
 _HITL_SOTA = bool(_DEVELOPER_CFG["hitl_sota"])
 
 _TASK_ROOT = Path(_PATH_CFG["task_root"])
-_OUTPUTS_DIRNAME = _PATH_CFG["outputs_dirname"]
 
 
 class DeveloperAgent:
     """Turns the Researcher plan into a runnable training script.
 
-    - Generates train.py in version folder: outputs/{iteration}/{version}/train.py
+    - Generates train.py in version folder: task/{slug}/{run_id}/{iteration}/{version}/train.py
     - Executes it and iterates while within a time budget
-    - Success condition: writes submission.csv at outputs/{iteration}/{version}/submission.csv
+    - Success condition: writes submission.csv at task/{slug}/{run_id}/{iteration}/{version}/submission.csv
     """
 
     # Class-level shared state across all parallel DeveloperAgent instances
@@ -80,6 +79,7 @@ class DeveloperAgent:
     def __init__(
         self,
         slug: str,
+        run_id: str,
         iteration: int | str,
         strategy_name: str | None = None,
         external_data_listing: str | None = None,
@@ -91,12 +91,10 @@ class DeveloperAgent:
     ):
         load_dotenv()
         self.slug = slug
-        self.iteration = (
-            iteration  # Can be int (legacy) or str like "1_1" (for parallel baselines)
-        )
+        self.run_id = run_id
+        self.iteration = iteration  # Per-strategy suffix (e.g. "1", "2", "3")
 
         self.task_root = _TASK_ROOT
-        self.outputs_dirname = _OUTPUTS_DIRNAME
         self.base_dir = self.task_root / slug
 
         # Fail fast if required helper files are missing
@@ -107,7 +105,7 @@ class DeveloperAgent:
         if not metric_path.exists():
             raise FileNotFoundError(f"Required file missing: {metric_path}")
 
-        self.outputs_dir = self.base_dir / self.outputs_dirname / str(iteration)
+        self.outputs_dir = self.base_dir / self.run_id / str(iteration)
         self.outputs_dir.mkdir(parents=True, exist_ok=True)
         self.developer_log_path = self.outputs_dir / f"developer_{iteration}.txt"
         self._configure_logger()
@@ -415,18 +413,12 @@ class DeveloperAgent:
         return header + "\n" + code, num_header_lines
 
     def _get_parent_iteration_folder(self) -> Path:
-        """Get parent iteration folder for copying shared files.
-
-        For example:
-        - If self.iteration is "16_2", returns outputs/16
-        - If self.iteration is "16", returns outputs/16
+        """Get parent run folder for shared per-run artifacts (external_data, etc.).
 
         Returns:
-            Path to parent iteration folder (e.g., task/csiro-biomass/outputs/16)
+            Path to the run container (e.g., task/csiro-biomass/<run_id>/)
         """
-        iteration_str = str(self.iteration)
-        base_iteration = iteration_str.split("_")[0]
-        return self.base_dir / self.outputs_dirname / base_iteration
+        return self.base_dir / self.run_id
 
     def _write_code(self, train_py: str, version: int) -> Path:
         """Write train.py and supporting files to a version folder.
@@ -983,6 +975,7 @@ class DeveloperAgent:
                 attempt_number=attempt_number,
                 slug=self.slug,
                 data_path=str(self.base_dir),
+                run_id=self.run_id,
                 cpu_core_range=self.cpu_core_range,
                 gpu_identifier=self.gpu_identifier,
                 file_suffix=str(

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -23,7 +23,6 @@ _RUNTIME_CFG = _CONFIG["runtime"]
 _PATH_CFG = _CONFIG["paths"]
 _DEVELOPER_CFG = _CONFIG["developer"]
 _TASK_ROOT = Path(_PATH_CFG["task_root"])
-_OUTPUTS_DIRNAME = _PATH_CFG["outputs_dirname"]
 _HITL_SOTA = bool(_DEVELOPER_CFG["hitl_sota"])
 
 
@@ -247,6 +246,7 @@ def _ensure_conda_environments(num_workers: int) -> None:
 @weave.op()
 def _run_developer_baseline(
     slug: str,
+    run_id: str,
     iteration_suffix: str,
     strategy_name: str,
     key: str,
@@ -261,7 +261,8 @@ def _run_developer_baseline(
 
     Args:
         slug: Competition slug
-        iteration_suffix: Iteration identifier (e.g., "1_1")
+        run_id: Orchestrator run identifier (timestamp dir under task/<slug>/)
+        iteration_suffix: Per-strategy suffix under the run (e.g., "1", "2", "3")
         strategy_name: Strategy name (e.g., "deberta-v3-large")
         key: Key for tracking results
         cpu_core_pool: Queue of CPU core ranges to grab from (None = no affinity)
@@ -277,6 +278,7 @@ def _run_developer_baseline(
         baseline_time_limit = _RUNTIME_CFG["baseline_time_limit"]
         dev = DeveloperAgent(
             slug,
+            run_id,
             iteration_suffix,
             strategy_name=strategy_name,
             external_data_listing=external_data_listing,
@@ -300,13 +302,13 @@ def _run_developer_baseline(
 
 class Orchestrator:
     def __init__(
-        self, slug: str, iteration: int, rollback_to_version: int | None = None
+        self, slug: str, run_id: str, rollback_to_version: int | None = None
     ):
         self.slug = slug
-        self.iteration = iteration
+        self.run_id = run_id
         self.rollback_to_version = rollback_to_version
         self.base_dir = _TASK_ROOT / slug
-        self.outputs_dir = self.base_dir / _OUTPUTS_DIRNAME / str(iteration)
+        self.outputs_dir = self.base_dir / self.run_id
 
     def _get_external_data_listing(self) -> str:
         """Get directory listing of external_data_* folders in outputs/<iteration>."""
@@ -337,7 +339,7 @@ class Orchestrator:
         Also removes baseline_results.json so affected models get re-run.
         """
         target = self.rollback_to_version
-        parent_outputs = self.base_dir / _OUTPUTS_DIRNAME
+        parent_outputs = self.outputs_dir
 
         found = False
         for iter_suffix in model_iterations:
@@ -419,7 +421,7 @@ class Orchestrator:
 
         if self.rollback_to_version is not None:
             model_iterations = [
-                f"{self.iteration}_{idx}"
+                str(idx)
                 for idx in range(1, len(strategy_list) + 1)
             ]
             self._rollback(model_iterations)
@@ -475,7 +477,7 @@ class Orchestrator:
             tasks = []
             for idx, strategy_name in enumerate(strategy_list, start=1):
                 key = strategy_name
-                dev_iter = f"{self.iteration}_{idx}"
+                dev_iter = str(idx)
 
                 conda_env = f"qgentic-strategy-{idx}"
 
@@ -491,6 +493,7 @@ class Orchestrator:
                 tasks.append(
                     (
                         self.slug,
+                        self.run_id,
                         dev_iter,
                         strategy_name,
                         key,

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,6 @@ runtime:
     - /workspace
 paths:
   task_root: "task"
-  outputs_dirname: "outputs"
   external_data_dirname: "external-data"
 guardrails:
   logging_basicconfig_order: true

--- a/launch_agent.py
+++ b/launch_agent.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import time
 from typing import Optional, Tuple
 
 from agents.orchestrator import Orchestrator
@@ -45,7 +46,7 @@ def _init_tracking(args: argparse.Namespace) -> None:
     """Initialise wandb and weave using the best available configuration."""
 
     entity, project = _resolve_wandb_target(args.wandb_entity, args.wandb_project)
-    run_name = getattr(args, "wandb_run_name", None) or f"{args.iteration}-{args.slug}"
+    run_name = getattr(args, "wandb_run_name", None) or f"{args.run_id}-{args.slug}"
 
     if not project:
         # Fall back to disabled mode so downstream wandb.log calls are no-ops.
@@ -64,13 +65,18 @@ def _init_tracking(args: argparse.Namespace) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Run Researcher+Developer pipeline")
     parser.add_argument("--slug", type=str, help="Competition slug under task/<slug>")
-    parser.add_argument("--iteration", type=int, help="Iteration number (e.g., 1)")
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        help="Run identifier (default: current timestamp %Y%m%d_%H%M%S)",
+    )
     parser.add_argument("--wandb-entity", type=str, help="Weights & Biases entity name")
     parser.add_argument("--wandb-project", type=str, help="Weights & Biases project name")
     parser.add_argument(
         "--wandb-run-name",
         type=str,
-        help="Optional wandb run name override (defaults to '<iteration>-<slug>')",
+        help="Optional wandb run name override (defaults to '<run_id>-<slug>')",
     )
     parser.add_argument(
         "--rollback-to-version",
@@ -80,10 +86,13 @@ def main():
     )
     args = parser.parse_args()
 
+    if args.run_id is None:
+        args.run_id = time.strftime("%Y%m%d_%H%M%S")
+
     os.environ["TASK_SLUG"] = args.slug
     _init_tracking(args)
 
-    orchestrator = Orchestrator(args.slug, args.iteration, rollback_to_version=args.rollback_to_version)
+    orchestrator = Orchestrator(args.slug, args.run_id, rollback_to_version=args.rollback_to_version)
     orchestrator.run()
 
     # Gracefully close tracking backends to avoid hanging background threads

--- a/tests/test_developer_agent.py
+++ b/tests/test_developer_agent.py
@@ -49,6 +49,7 @@ def test_agent_initialization(test_task_dir, monkeypatch):
 
     agent = DeveloperAgent(
         slug=test_task_dir["slug"],
+        run_id="20260418_000000",
         iteration=test_task_dir["iteration"],
         strategy_name="test-strategy",
         plan_content="Test plan",

--- a/tests/test_developer_tools.py
+++ b/tests/test_developer_tools.py
@@ -222,6 +222,7 @@ def test_search_sota_suggestions(monkeypatch, test_data_dir):
         failed_ideas=["Idea 1", "Idea 2"],
         slug="test-competition",
         data_path=test_data_dir,
+        run_id="20260418_000000",
         shared_suggestions=None,
         external_data_listing=None,
         plan_content=None,
@@ -267,6 +268,7 @@ def test_search_sota_suggestions_with_plan_content(monkeypatch, test_data_dir):
         failed_ideas=[],
         slug="test-competition",
         data_path=test_data_dir,
+        run_id="20260418_000000",
         shared_suggestions=None,
         external_data_listing=None,
         plan_content=plan_content,
@@ -310,6 +312,7 @@ def test_search_sota_suggestions_with_tools(monkeypatch, test_data_dir):
         failed_ideas=[],
         slug="test-competition",
         data_path=test_data_dir,
+        run_id="20260418_000000",
         cpu_core_range=[0, 1],
         gpu_identifier="0",
     )
@@ -352,6 +355,7 @@ def test_search_sota_suggestions_early_exit_forces_structured_output(
         failed_ideas=[],
         slug="test-comp",
         data_path=test_data_dir,
+        run_id="20260418_000000",
     )
 
     assert hasattr(result, "suggestion")
@@ -390,6 +394,7 @@ def test_search_sota_suggestions_without_tools(monkeypatch, test_data_dir):
         failed_ideas=[],
         slug="test-competition",
         data_path=test_data_dir,
+        run_id="20260418_000000",
     )
 
     assert hasattr(result, "suggestion")

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -55,7 +55,6 @@ _BASELINE_TIME_LIMIT = _RUNTIME_CFG["baseline_time_limit"]
 _BASELINE_CODE_TIMEOUT = _RUNTIME_CFG["baseline_code_timeout"]
 _LOG_MONITOR_INTERVAL = _RUNTIME_CFG["log_monitor_interval"]
 _PATH_CFG = _CONFIG["paths"]
-_OUTPUTS_DIRNAME = _PATH_CFG["outputs_dirname"]
 
 
 def _build_resource_header(
@@ -233,6 +232,7 @@ def search_sota_suggestions(
     failed_ideas: list[str],
     slug: str,
     data_path: str,
+    run_id: str,
     shared_suggestions: list[str] | None = None,
     external_data_listing: str | None = None,
     plan_content: str | None = None,
@@ -372,6 +372,7 @@ def search_sota_suggestions(
                     description=description,
                     data_path=data_path,
                     slug=slug,
+                    run_id=run_id,
                     cpu_core_range=cpu_core_range,
                     gpu_identifier=gpu_identifier,
                     file_suffix=file_suffix,
@@ -419,6 +420,7 @@ def _execute_sota_tool_call(
     description,
     data_path,
     slug,
+    run_id,
     cpu_core_range,
     gpu_identifier,
     file_suffix,
@@ -429,6 +431,7 @@ def _execute_sota_tool_call(
 
     Args:
         item: Gemini function_call object
+        run_id: Orchestrator run identifier (timestamp dir under task/<slug>/)
         step: Current tool loop step (for unique filenames)
         version: Current developer version (for output directory)
     """
@@ -438,7 +441,7 @@ def _execute_sota_tool_call(
         code = args["code"]
         logger.info("SOTA tool: execute_python (code_len=%d, step=%d)", len(code), step)
 
-        version_dir = Path(data_path) / _OUTPUTS_DIRNAME / file_suffix / str(version)
+        version_dir = Path(data_path) / run_id / file_suffix / str(version)
         version_dir.mkdir(parents=True, exist_ok=True)
         script_file = version_dir / f"execute_python_{step}.py"
 

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import time
 
 from google import genai
@@ -105,40 +106,35 @@ def _retry_with_backoff(func, *, max_retries, backoff_sequence):
     raise last_exception
 
 
+_RUN_ID_PATTERN = re.compile(r"^\d{8}_\d{6}$")
+
+
 def _build_directory_listing(root: str, num_files: int | None = None) -> str:
     cfg = get_config()
     runtime_cfg = cfg["runtime"]
-    path_cfg = cfg["paths"]
     limit = (
         num_files
         if num_files is not None
         else runtime_cfg["directory_listing_max_files"]
     )
     lines: list[str] = []
-    outputs_dirname = path_cfg["outputs_dirname"]
 
     for current_root, dirs, files in os.walk(root):
         rel_root = os.path.relpath(current_root, root)
 
-        # Determine traversal policy for the outputs tree: allow only external_data_*/ contents
+        # Determine traversal policy for the run_id tree: allow only external_data/ contents
         segments = [] if rel_root in (".", "") else rel_root.split(os.sep)
         files_to_show = files
 
-        if segments and segments[0] == outputs_dirname:
-            # At <root>/outputs
+        if segments and _RUN_ID_PATTERN.match(segments[0]):
+            # At <root>/<run_id>
             if len(segments) == 1:
-                # Only descend into iteration directories that are numeric; hide files at this level
-                dirs[:] = sorted([d for d in dirs if d.isdigit()])
-                files_to_show = []
-            # At <root>/outputs/<iteration>
-            elif len(segments) == 2:
-                # Only descend into the external_data subdirectory; hide files at this level
+                # Only descend into external_data; hide per-iteration noise
                 dirs[:] = sorted([d for d in dirs if d == "external_data"])
                 files_to_show = []
             else:
-                # At or below <root>/outputs/<iteration>/*
-                # Allow full traversal within external_data; block others entirely
-                if len(segments) >= 3 and segments[2] == "external_data":
+                # At or below <root>/<run_id>/*
+                if segments[1] == "external_data":
                     dirs[:] = sorted(dirs)
                     files_to_show = files
                 else:


### PR DESCRIPTION
## Summary
- Introduce a timestamped per-run container directory `task/<slug>/<run_id>/`, replacing the old `task/<slug>/outputs/<iteration>/` nesting. Matches the goal-mode layout (`goal_mode.py:134`).
- `run_id = time.strftime("%Y%m%d_%H%M%S")` is generated in `launch_agent.py` (the CLI entry point) and threaded into `Orchestrator` and `DeveloperAgent`. No default inside Orchestrator — callers must pass.
- `Orchestrator.__init__(slug, run_id, rollback_to_version=None)` — drops `iteration`; `self.outputs_dir = self.base_dir / self.run_id`.
- `DeveloperAgent.__init__(slug, run_id, iteration, …)` — adds `run_id`; `self.outputs_dir = self.base_dir / run_id / str(iteration)` (where `iteration` is now just the per-strategy suffix like `"1"`, `"2"`, `"3"`).
- `_run_developer_baseline` signature updated to pass `run_id` through.
- Orchestrator's `_rollback` walks `self.outputs_dir` directly (no more `outputs_dirname` lookup).
- SOTA dispatch path in `tools/developer.py` updated to use `run_id` (PR 226 later deletes SOTA entirely).
- Directory-listing helper in `tools/helpers.py` switches from hard-coded `outputs_dirname` matching to a timestamp-pattern regex (`\d{8}_\d{6}`) for the run dir.
- CLI: replace `--iteration` with `--run-id` (optional; defaults to timestamp in `launch_agent.py`). wandb run name template becomes `<run_id>-<slug>`.
- Config: drop `paths.outputs_dirname` (no longer referenced).
- Tests: `tests/test_developer_agent.py` now passes `run_id="20260418_000000"`. SOTA tests in `tests/test_developer_tools.py` inject `run_id` kwarg too (these tests are deleted in PR 226).

## Files
- Modified: `agents/orchestrator.py`, `agents/developer.py`, `tools/developer.py`, `tools/helpers.py`, `config.yaml`, `launch_agent.py`, `tests/test_developer_agent.py`, `tests/test_developer_tools.py`.

## Test plan
- [x] `grep -r "outputs_dirname\|_OUTPUTS_DIRNAME" --include="*.py" --include="*.yaml"` returns zero matches.
- [x] `python -c "from agents.orchestrator import Orchestrator; from agents.developer import DeveloperAgent; o = Orchestrator('nop', '20260418_000000')"` constructs cleanly.
- [x] `pytest tests/ -q --ignore=tests/test_research.py` — 47 tests pass on this branch (with SOTA tests still present; they flow through the cleanup in PR 226).
- [ ] End-to-end orchestrator run — writes `task/<slug>/<YYYYMMDD_HHMMSS>/1/train.py` instead of `task/<slug>/outputs/<iter>/<ver>/train.py`.
- [ ] CI: unit tests.