### PR TITLE
remove time limit from goal developer

### DIFF
--- a/agents/goal_developer.py
+++ b/agents/goal_developer.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -86,9 +85,8 @@ def run_goal_mode(
     goal_text: str,
     run_dir: Path,
     max_versions: int = 50,
-    max_time_seconds: int = 6 * 3600,
 ) -> list[HistoryEntry]:
-    """Run the goal-mode loop until the reviewer reports done or limits hit.
+    """Run the goal-mode loop until the reviewer reports done or ``max_versions`` is hit.
 
     Writes per-version artifacts under ``run_dir/v{N}/`` and a summary
     ``history.json`` under ``run_dir/``. Returns the full history.
@@ -101,13 +99,7 @@ def run_goal_mode(
         append_message("user", initial_codegen_user(v1_dir))
     ]
 
-    deadline = time.monotonic() + max_time_seconds
-
     for version in range(1, max_versions + 1):
-        if time.monotonic() >= deadline:
-            logger.info("max_time_seconds reached before v%s", version)
-            break
-
         version_dir = run_dir / f"v{version}"
         version_dir.mkdir(parents=True, exist_ok=True)
         next_dir = run_dir / f"v{version + 1}"

--- a/goal_mode.py
+++ b/goal_mode.py
@@ -94,12 +94,6 @@ def main() -> None:
         help="Maximum number of iterations (default: 500).",
     )
     parser.add_argument(
-        "--max-time-seconds",
-        type=int,
-        default=432 * 3600,
-        help="Wall-clock budget in seconds (default: 432 hours).",
-    )
-    parser.add_argument(
         "--wandb-entity",
         type=str,
         default=None,
@@ -142,7 +136,6 @@ def main() -> None:
             goal_text=goal_text,
             run_dir=run_dir,
             max_versions=args.max_versions,
-            max_time_seconds=args.max_time_seconds,
         )
     finally:
         # Gracefully close tracking backends to avoid hanging background threads.

--- a/tests/test_goal_developer.py
+++ b/tests/test_goal_developer.py
@@ -98,7 +98,6 @@ def test_terminates_on_done(fake_pipeline, tmp_path):
         goal_text="Write `hello` to out.txt",
         run_dir=tmp_path / "run",
         max_versions=10,
-        max_time_seconds=60,
     )
     assert len(history) == 1
     assert history[0].review is not None and history[0].review.done is True
@@ -121,7 +120,6 @@ def test_iterates_until_max_versions(fake_pipeline, tmp_path):
         goal_text="Write `hello` to out.txt",
         run_dir=tmp_path / "run",
         max_versions=3,
-        max_time_seconds=60,
     )
     assert len(history) == 3
     assert all(entry.review and entry.review.done is False for entry in history)
@@ -150,7 +148,6 @@ def test_review_failure_yields_degraded_entry(fake_pipeline, tmp_path):
         goal_text="Write `hello` to out.txt",
         run_dir=tmp_path / "run",
         max_versions=3,
-        max_time_seconds=60,
     )
     assert len(history) == 2
     assert history[0].review is not None
@@ -180,7 +177,6 @@ def test_guardrails_block_skips_execution(monkeypatch, fake_pipeline, tmp_path):
         goal_text="Write `hello` to out.txt",
         run_dir=tmp_path / "run",
         max_versions=3,
-        max_time_seconds=60,
     )
     # v1 was blocked, v2 ran and the reviewer marked it done.
     assert len(history) == 2
@@ -197,7 +193,6 @@ def test_history_json_persisted(fake_pipeline, tmp_path):
         goal_text="Write `hello` to out.txt",
         run_dir=tmp_path / "run",
         max_versions=10,
-        max_time_seconds=60,
     )
     history_path = tmp_path / "run" / "history.json"
     assert history_path.exists()


### PR DESCRIPTION
## Summary
- Drops the `max_time_seconds` parameter and deadline check from `agents/goal_developer.py:run_goal_mode`.
- Removes the corresponding `--max-time-seconds` CLI arg in `goal_mode.py`.
- Removes the now-unused `import time` in `agents/goal_developer.py`.
- Strips `max_time_seconds=60` from all five call sites in `tests/test_goal_developer.py`.

Aligns the developer loop with the "no timer-based termination — user SIGKILLs pathological runs" principle we're converging on for the Main Agent redesign (#230). `max_versions` remains as the only self-terminator for now.

## Test plan
- [x] `pytest tests/test_goal_developer.py -q` passes.
- [x] `python goal_mode.py --help` no longer lists `--max-time-seconds`.
- [x] `python -c "import inspect; from agents.goal_developer import run_goal_mode; print(inspect.signature(run_goal_mode))"` shows no `max_time_seconds` param.