### PR TITLE
add idea-pool helpers for MainAgent memory

### DIFF
--- a/tests/test_idea_pool.py
+++ b/tests/test_idea_pool.py
@@ -1,0 +1,51 @@
+"""Unit tests for the idea-pool helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils import idea_pool
+from utils.idea_pool import add_idea, load_index, remove_idea, update_idea
+
+
+def test_full_lifecycle(tmp_path):
+    ideas_dir = tmp_path / "ideas"
+    ideas_dir.mkdir()
+
+    # add: monotonic ids, slugified filenames, title as H1
+    assert [add_idea(ideas_dir, t, f"body-{t}") for t in ("alpha", "beta", "gamma")] == [1, 2, 3]
+    assert (ideas_dir / "001_alpha.md").read_text() == "# alpha\n\nbody-alpha\n"
+
+    # render_index wrote INDEX.md in id order
+    index = load_index(ideas_dir)
+    assert "- [001] alpha" in index
+    assert index.index("[001]") < index.index("[002]") < index.index("[003]")
+
+    # update: title stays, body replaced
+    update_idea(ideas_dir, 1, "new body")
+    assert (ideas_dir / "001_alpha.md").read_text() == "# alpha\n\nnew body\n"
+
+    # remove: file gone, index updated, subsequent add takes max+1 (no id reuse)
+    remove_idea(ideas_dir, 2)
+    assert not (ideas_dir / "002_beta.md").exists()
+    assert "beta" not in load_index(ideas_dir)
+    assert add_idea(ideas_dir, "delta", "d") == 4
+
+    # missing id on remove/update raises ValueError (unpacking zero-length glob)
+    with pytest.raises(ValueError):
+        remove_idea(ideas_dir, 99)
+    with pytest.raises(ValueError):
+        update_idea(ideas_dir, 99, "nope")
+
+
+def test_load_index_truncation_warning(monkeypatch, tmp_path):
+    ideas_dir = tmp_path / "ideas"
+    ideas_dir.mkdir()
+    monkeypatch.setattr(idea_pool, "MAX_INDEX_LINES", 5)
+
+    for i in range(10):
+        add_idea(ideas_dir, f"idea-{i}", "body")
+
+    loaded = load_index(ideas_dir)
+    assert "WARNING" in loaded
+    assert loaded.rstrip().endswith("Prune the pool.")

--- a/utils/idea_pool.py
+++ b/utils/idea_pool.py
@@ -1,0 +1,90 @@
+"""Idea-pool storage for the Main Agent.
+
+Flat-file layout under ``task/<slug>/<run_id>/ideas/``:
+
+    ideas/
+    ├── INDEX.md                       # regenerated on every mutation
+    ├── 001_try_random_forest.md
+    ├── 002_add_external_dataset.md
+    └── ...
+
+Each idea file is pure markdown with the title as the first ``# H1``. The
+integer id lives as a zero-padded prefix in the filename so lookups and
+orderings are cheap. INDEX.md is a one-line-per-idea summary that MainAgent
+always has in its system prompt; ``load_index`` applies line + byte caps
+(mirroring ``claude-code/memdir/memdir.ts:truncateEntrypointContent``) with a
+trailing warning when the pool outgrows them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_INDEX_FILENAME = "INDEX.md"
+_INDEX_HEADER = "# Idea pool"
+_H1 = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+
+MAX_INDEX_LINES = 200
+MAX_INDEX_BYTES = 25_000
+
+
+def _truncate_with_warning(content: str) -> str:
+    trimmed = content.rstrip("\n")
+    lines = trimmed.split("\n")
+    if len(lines) <= MAX_INDEX_LINES and len(trimmed) <= MAX_INDEX_BYTES:
+        return trimmed + "\n"
+    truncated = "\n".join(lines[:MAX_INDEX_LINES])
+    if len(truncated) > MAX_INDEX_BYTES:
+        cut = truncated.rfind("\n", 0, MAX_INDEX_BYTES)
+        truncated = truncated[:cut]
+    warning = (
+        f"\n\n> WARNING: {_INDEX_FILENAME} truncated at {MAX_INDEX_LINES} "
+        f"lines / {MAX_INDEX_BYTES} bytes. Prune the pool."
+    )
+    return truncated + warning + "\n"
+
+
+def render_index(ideas_dir: Path) -> str:
+    entries = sorted(
+        (int(p.stem.split("_", 1)[0]), p)
+        for p in ideas_dir.glob("[0-9][0-9][0-9]_*.md")
+    )
+    lines = [_INDEX_HEADER, ""]
+    for idea_id, path in entries:
+        title = _H1.search(path.read_text()).group(1).strip()
+        lines.append(f"- [{idea_id:03d}] {title}")
+    content = "\n".join(lines) + "\n"
+    (ideas_dir / _INDEX_FILENAME).write_text(content)
+    return content
+
+
+def load_index(ideas_dir: Path) -> str:
+    return _truncate_with_warning((ideas_dir / _INDEX_FILENAME).read_text())
+
+
+def add_idea(ideas_dir: Path, title: str, description: str) -> int:
+    existing = [
+        int(p.stem.split("_", 1)[0])
+        for p in ideas_dir.glob("[0-9][0-9][0-9]_*.md")
+    ]
+    idea_id = (max(existing) + 1) if existing else 1
+    slug = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+    (ideas_dir / f"{idea_id:03d}_{slug}.md").write_text(
+        f"# {title}\n\n{description}\n"
+    )
+    render_index(ideas_dir)
+    return idea_id
+
+
+def remove_idea(ideas_dir: Path, idea_id: int) -> None:
+    (path,) = ideas_dir.glob(f"{idea_id:03d}_*.md")
+    path.unlink()
+    render_index(ideas_dir)
+
+
+def update_idea(ideas_dir: Path, idea_id: int, description: str) -> None:
+    (path,) = ideas_dir.glob(f"{idea_id:03d}_*.md")
+    title = _H1.search(path.read_text()).group(1).strip()
+    path.write_text(f"# {title}\n\n{description}\n")
+    render_index(ideas_dir)


### PR DESCRIPTION
## Summary
Phase 3 of the MainAgent implementation stack (#230). Adds the flat-file idea-pool storage MainAgent will use as its working-memory scratchpad. Memdir-inspired layout (see `claude-code/memdir/memdir.ts`), intentionally stripped of frontmatter / type taxonomy / relevance-selector pass — we only need id + title, and both live in the filename.

### `utils/idea_pool.py`

Layout:

```
task/<slug>/<run_id>/ideas/
├── INDEX.md                       # regenerated on every mutation
├── 001_try_random_forest.md
├── 002_add_external_dataset.md
└── ...
```

- Each idea file: pure markdown, title as first `# H1`, description as body. No YAML frontmatter.
- Filename: `<id:03d>_<slug>.md`. Id monotonic per run; `max(existing) + 1`, no reuse across removes.
- `INDEX.md`: `- [001] title\n- [002] title\n...` regenerated after every add/remove/update. Always in MainAgent's system prompt so it sees the pool at a glance.

Public API (5 functions, ~45 LOC total):
- `add_idea(ideas_dir, title, description) -> int` — write file + regen index; returns id.
- `remove_idea(ideas_dir, idea_id)` — unlink + regen. Raises `ValueError` on missing id (via zero-length glob unpack).
- `update_idea(ideas_dir, idea_id, description)` — replace body; title preserved from existing H1.
- `render_index(ideas_dir) -> str` — regenerate INDEX.md from current files, return content.
- `load_index(ideas_dir) -> str` — read INDEX.md with line/byte cap + trailing truncation warning (mirroring `memdir.ts:truncateEntrypointContent`). `MAX_INDEX_LINES=200`, `MAX_INDEX_BYTES=25_000`.

Framework owns both sides of the contract, so the code is aggressively unconservative — no empty-title handling, no missing-H1 fallback, no `mkdir(parents=True)` inside mutators (MainAgent's init creates `ideas/` once), no custom exception wrapping. Bad id → `ValueError` from tuple-unpack on a zero-length glob. Bad body → regex `NoneType.group` at the author site so we notice immediately.

### `tests/test_idea_pool.py`

Two tests, minimal coverage:

- `test_full_lifecycle` — add 3 in sequence → verify monotonic ids, filename slug, H1 body, index ordering. Update one → verify title preserved + body replaced. Remove one → verify file + index updated, next `add_idea` returns `max+1` (no reuse). Missing-id → `remove_idea(99)` / `update_idea(99)` both raise `ValueError`.
- `test_load_index_truncation_warning` — monkey-patch `MAX_INDEX_LINES=5`, add 10 ideas, assert truncation warning appended.

## Test plan
- [x] `pytest tests/test_idea_pool.py -q` → 2 passed.
- [x] `pytest tests/ -q` → 51 passed (49 pre-existing + 2 new).