### PR TITLE
add MainAgent: function-calling loop with developer/researcher/execute_python/idea-pool tools

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -351,11 +351,11 @@ class DeveloperAgent:
             logger.info("explore_codebase called: %s", query[:100])
             return explore_codebase(query, goal_text=self.goal_text)
 
-        if function_call.name == "execute_python":
+        if function_call.name == "analyze":
             code = args["code"]
             timeout = args.get("timeout_seconds", 300)
             logger.info(
-                "execute_python called (step %s call %s, %d bytes, timeout=%ds)",
+                "analyze called (step %s call %s, %d bytes, timeout=%ds)",
                 step,
                 call_idx,
                 len(code),

--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -1,0 +1,180 @@
+"""Main Agent — top-level LLM-driven orchestrator.
+
+Infinite function-calling loop that picks from four tool categories every
+step: `developer` / `researcher` (subagents), `analyze` (leaf), and
+memory ops (`add_idea` / `remove_idea` / `update_idea`). No termination in
+software — user SIGKILLs the process when satisfied.
+
+Session-level context: `GOAL.md` (threaded into every subagent's system
+prompt) and `task/<slug>/<run_id>/ideas/INDEX.md` (always-resident, regenerated
+after every idea-pool mutation).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import weave
+from google.genai import types
+
+from agents.developer import DeveloperAgent
+from agents.researcher import ResearcherAgent
+from project_config import get_config
+from prompts.main_agent import build_system
+from tools.developer import _build_resource_header, execute_code
+from tools.helpers import call_llm
+from utils.idea_pool import add_idea, load_index, remove_idea, update_idea
+from utils.llm_utils import append_message, get_main_agent_tools
+
+
+_INITIAL_USER_TURN = (
+    "Take your first step. The session goal, the current idea pool (INDEX.md), "
+    "and your tool palette are all in the system prompt. Pick a tool and call "
+    "it — every step should be a tool call, never a plain text response."
+)
+
+
+logger = logging.getLogger(__name__)
+
+_CONFIG = get_config()
+_TASK_ROOT = Path(_CONFIG["paths"]["task_root"])
+_MAIN_AGENT_MODEL = _CONFIG["llm"]["main_agent_model"]
+_EXECUTE_PYTHON_TIMEOUT = 600
+
+
+class MainAgent:
+    """Top-level LLM-driven orchestrator. See module docstring."""
+
+    def __init__(self, slug: str, run_id: str, goal_text: str):
+        self.slug = slug
+        self.run_id = run_id
+        self.goal_text = goal_text
+        self.base_dir = _TASK_ROOT / slug / run_id
+        self.ideas_dir = self.base_dir / "ideas"
+        self.snippets_dir = self.base_dir / "main_agent_snippets"
+        self.chat_log = self.base_dir / "main_agent_chat.jsonl"
+        for d in (self.ideas_dir, self.snippets_dir):
+            d.mkdir(parents=True, exist_ok=True)
+        self.dev_iter = 0
+        self.research_iter = 0
+        # google-genai requires at least one content entry per call; seed with
+        # a canonical starter user turn so the first `_step()` has something to
+        # send. Subsequent steps accumulate model responses + tool results in
+        # this list.
+        self.input_list: list[dict] = [append_message("user", _INITIAL_USER_TURN)]
+        # Ensure INDEX.md exists so `load_index` has something to read.
+        if not (self.ideas_dir / "INDEX.md").exists():
+            (self.ideas_dir / "INDEX.md").write_text("# Idea pool\n\n")
+
+    @weave.op()
+    def run(self) -> None:
+        tools = get_main_agent_tools()
+        while True:
+            self._step(tools)
+
+    def _step(self, tools) -> None:
+        system_prompt = build_system(
+            slug=self.slug,
+            goal_text=self.goal_text,
+            index_md=load_index(self.ideas_dir),
+        )
+        response = call_llm(
+            model=_MAIN_AGENT_MODEL,
+            system_instruction=system_prompt,
+            messages=self.input_list,
+            function_declarations=tools,
+            enable_google_search=False,
+        )
+
+        parts = response.candidates[0].content.parts
+        has_function_calls = any(
+            p.function_call for p in parts if hasattr(p, "function_call")
+        )
+
+        self.input_list.append(
+            response.candidates[0].content.model_dump(mode="json", exclude_none=True)
+        )
+        self._log({"role": "assistant", "content": response.candidates[0].content.model_dump(mode="json", exclude_none=True)})
+
+        if not has_function_calls:
+            logger.warning(
+                "MainAgent emitted text-only response; nudging back to tool use"
+            )
+            return
+
+        function_responses = []
+        for part in parts:
+            if hasattr(part, "function_call") and part.function_call:
+                fc = part.function_call
+                result = self._dispatch(fc.name, dict(fc.args))
+                function_responses.append(
+                    types.Part.from_function_response(
+                        name=fc.name,
+                        response={"result": result},
+                    )
+                )
+                self._log({"role": "tool", "name": fc.name, "args": dict(fc.args), "result": result})
+
+        self.input_list.append(
+            types.Content(role="function", parts=function_responses).model_dump(
+                mode="json", exclude_none=True
+            )
+        )
+
+    def _dispatch(self, name: str, args: dict) -> str:
+        if name == "develop":
+            idea_text: str | None = None
+            if "idea_id" in args:
+                idea_id = int(args["idea_id"])
+                matches = list(self.ideas_dir.glob(f"{idea_id:03d}_*.md"))
+                if not matches:
+                    return json.dumps({"error": f"unknown idea_id: {idea_id}"})
+                idea_text = matches[0].read_text()
+            self.dev_iter += 1
+            dev = DeveloperAgent(
+                slug=self.slug,
+                run_id=self.run_id,
+                dev_iter=self.dev_iter,
+                goal_text=self.goal_text,
+            )
+            payload = dev.run(idea=idea_text)
+            return json.dumps(payload)
+
+        if name == "research":
+            self.research_iter += 1
+            res = ResearcherAgent(
+                slug=self.slug,
+                run_id=self.run_id,
+                research_iter=self.research_iter,
+                goal_text=self.goal_text,
+            )
+            return res.run(instruction=args["instruction"])
+
+        if name == "analyze":
+            snippet_num = len(list(self.snippets_dir.glob("*.py"))) + 1
+            script_file = self.snippets_dir / f"{snippet_num:03d}.py"
+            script_file.write_text(_build_resource_header() + args["code"])
+            job = execute_code(str(script_file), timeout_seconds=_EXECUTE_PYTHON_TIMEOUT)
+            return json.dumps({"output": job.result()})
+
+        if name == "add_idea":
+            idea_id = add_idea(self.ideas_dir, args["title"], args["description"])
+            return json.dumps({"idea_id": idea_id})
+
+        if name == "remove_idea":
+            remove_idea(self.ideas_dir, args["idea_id"])
+            return json.dumps({"ok": True})
+
+        if name == "update_idea":
+            update_idea(self.ideas_dir, args["idea_id"], args["description"])
+            return json.dumps({"ok": True})
+
+        return json.dumps({"error": f"Unknown tool: {name}"})
+
+    def _log(self, record: dict) -> None:
+        record["ts"] = datetime.now(timezone.utc).isoformat()
+        with self.chat_log.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 llm:
+  main_agent_model: "gemini-3.1-pro-preview"
   developer_model: "gemini-3.1-pro-preview"
   developer_tool_model: "gemini-3.1-pro-preview"
   leakage_review_model: "gemini-3.1-pro-preview"

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -1,0 +1,61 @@
+"""System prompt builder for the top-level agent."""
+
+from __future__ import annotations
+
+
+def build_system(slug: str, goal_text: str, index_md: str) -> str:
+    return f"""You orchestrate a team of subagents for a Qgentic-AI run on competition '{slug}'. Drive iteration toward the session goal below using the tool palette — every step is a tool call.
+
+# Session Goal
+
+{goal_text}
+
+---
+
+# Current idea pool
+
+INDEX.md is regenerated after every idea-pool mutation. Individual idea bodies live at `task/{slug}/<run_id>/ideas/<id>_<slug-title>.md`. Call `develop(idea_id=NNN)` with the integer prefix from INDEX.md — the framework resolves the id to the idea's full markdown body before handing it to the developer subagent.
+
+{index_md}
+
+---
+
+# Your tool palette
+
+- `develop(idea_id?: int)` — subagent; writes and runs a `train.py`, retries internally until it produces `train_stats.json`. Returns `{{status, code, code_path, summary: {{score, stats, stdout_tail, attempts_made, final_error}}}}`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself.
+- `researcher(instruction: str)` — subagent; web-grounded research with `web_fetch` + `web_search` and internal Python for analysis/probing. Returns a markdown report with URL citations. Use for domain grounding, library docs, empirical sniff-tests on data.
+- `analyze(code: str)` — leaf tool for **inspection and analysis only**; runs the Python you pass and returns stdout/stderr. Legitimate uses: read files, inspect prior developer outputs, reproduce a score, grep for leakage patterns, compute analysis of `valid_preds.csv`, list directory contents. **Not for:** authoring submission artifacts (that's `develop`'s job), modifying the Python environment (`pip install`, `apt`, etc.), long training runs, anything with real side effects. If you find yourself iterating on the solution artifact itself via `analyze`, stop and call `developer(idea=...)` instead.
+- `add_idea(title: str, description: str)` — add an entry to the pool; returns the assigned integer id. INDEX.md above regenerates automatically.
+- `remove_idea(idea_id: int)` — remove a dead idea.
+- `update_idea(idea_id: int, description: str)` — revise an existing idea's body. Title stays.
+
+# CRITICAL: do not do the developer's job yourself
+
+`analyze` is for inspection only. When what you want is "produce the thing we'd submit", call `develop(idea=...)` and let the developer subagent do it inside its own retry loop.
+
+# CRITICAL: verify subagent outputs
+
+You cannot assume any subagent is 100% correct. Every subagent result — especially `develop` — must be reviewed before you accept it.
+
+When `develop` returns `status="success"`:
+- Read the `code` field. Did the `train.py` actually implement the idea you gave it, or did it drift?
+- Check `summary.score` against `summary.stats`. Does the score line up with the internal validation metrics? Does it look suspiciously perfect (leakage)?
+- Use `analyze` to spot-check: read sibling artifacts at `code_path`'s directory (e.g. `valid_preds.csv`, `train.txt`), reproduce the score, grep the code for common leakage patterns (`train.merge(test)`, fitting a scaler on full data before the split, fillna with statistics computed across train+test).
+- If anything's fishy: add a remediation idea to the pool describing what to fix, and deprioritize or remove the current idea.
+
+When `research` returns a markdown report: URLs are guaranteed to exist and have been read, but the subagent's conclusions are not independently verified. If you're about to build on a claim, spot-check the key parts with `analyze` or another `research` call.
+
+# Intended rhythm
+
+The default pattern after each `developer(idea=...)` call:
+1. Read the return payload + any artifacts via `analyze`.
+2. Form an independent opinion on whether the attempt actually worked.
+3. Update the idea pool: mark what worked, add follow-ups or remediation ideas, remove dead ends.
+4. Pick the next idea and call `develop` again — or call `research` first if you need grounding.
+
+You're free to call `research` / `analyze` / memory ops zero or many times between developer calls — whatever the current state needs. But do not call `develop` back-to-back without at least inspecting the prior result.
+
+# Termination
+
+There is no termination condition in software. The user stops the process when satisfied. Keep iterating — every call should materially advance toward the goal. Do not emit a plain text response; every step should be a tool call.
+"""

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -1,0 +1,159 @@
+"""Unit tests for the MainAgent dispatch loop."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agents import main_agent
+from agents.main_agent import MainAgent
+
+
+def _fake_fc(name: str, **args):
+    """Build a response whose single part is a function_call matching the given name/args."""
+    fc = SimpleNamespace(name=name, args=args)
+    part = SimpleNamespace(function_call=fc)
+    content = SimpleNamespace(parts=[part])
+    content.model_dump = lambda **_: {
+        "role": "model",
+        "parts": [{"function_call": {"name": name, "args": dict(args)}}],
+    }
+    candidate = SimpleNamespace(content=content)
+    return SimpleNamespace(candidates=[candidate])
+
+
+def _fake_text(text: str):
+    """Build a text-only response (no function_call attribute on the part)."""
+    part = SimpleNamespace(text=text)  # intentionally has no function_call
+    content = SimpleNamespace(parts=[part])
+    content.model_dump = lambda **_: {"role": "model", "parts": [{"text": text}]}
+    candidate = SimpleNamespace(content=content)
+    return SimpleNamespace(candidates=[candidate])
+
+
+@pytest.fixture
+def patched_main_agent(monkeypatch, tmp_path):
+    monkeypatch.setattr(main_agent, "_TASK_ROOT", tmp_path / "task")
+
+    monkeypatch.setattr(
+        main_agent,
+        "execute_code",
+        lambda filepath, timeout_seconds=None: SimpleNamespace(
+            result=lambda: f"ran {Path(filepath).name}"
+        ),
+    )
+
+    dev_calls: list = []
+
+    class FakeDeveloperAgent:
+        def __init__(self, slug, run_id, dev_iter, goal_text):
+            dev_calls.append(
+                {
+                    "slug": slug,
+                    "run_id": run_id,
+                    "dev_iter": dev_iter,
+                    "goal_text": goal_text,
+                }
+            )
+            self.dev_iter = dev_iter
+
+        def run(self, idea):
+            dev_calls[-1]["idea"] = idea
+            return {
+                "status": "success",
+                "code": "# fake",
+                "code_path": f"dev_{self.dev_iter}",
+                "summary": {
+                    "score": 0.5,
+                    "stats": {},
+                    "stdout_tail": "",
+                    "attempts_made": 1,
+                    "final_error": None,
+                },
+            }
+
+    monkeypatch.setattr(main_agent, "DeveloperAgent", FakeDeveloperAgent)
+
+    research_calls: list = []
+
+    class FakeResearcherAgent:
+        def __init__(self, slug, run_id, research_iter, goal_text):
+            research_calls.append(
+                {
+                    "slug": slug,
+                    "run_id": run_id,
+                    "research_iter": research_iter,
+                    "goal_text": goal_text,
+                }
+            )
+
+        def run(self, instruction):
+            return f"# report\n\nResearched: {instruction}"
+
+    monkeypatch.setattr(main_agent, "ResearcherAgent", FakeResearcherAgent)
+
+    return {"dev_calls": dev_calls, "research_calls": research_calls}
+
+
+def test_dispatches_each_tool(patched_main_agent, monkeypatch):
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+
+    responses = iter(
+        [
+            _fake_fc("add_idea", title="try it", description="body"),
+            _fake_fc("update_idea", idea_id=1, description="body v2"),
+            _fake_fc("develop", idea_id=1),
+            _fake_fc("research", instruction="look up X"),
+            _fake_fc("analyze", code="print('hi')"),
+            _fake_fc("remove_idea", idea_id=1),
+        ]
+    )
+    monkeypatch.setattr(main_agent, "call_llm", lambda **kwargs: next(responses))
+
+    for _ in range(6):
+        agent._step([])
+
+    # developer + researcher subagents invoked once each with threaded goal_text
+    assert len(patched_main_agent["dev_calls"]) == 1
+    assert patched_main_agent["dev_calls"][0]["goal_text"] == "do the thing"
+    assert patched_main_agent["dev_calls"][0]["dev_iter"] == 1
+    # develop resolved idea_id=1 → full file body (includes the updated description "body v2")
+    assert "body v2" in patched_main_agent["dev_calls"][0]["idea"]
+    assert len(patched_main_agent["research_calls"]) == 1
+    assert patched_main_agent["research_calls"][0]["research_iter"] == 1
+    assert patched_main_agent["research_calls"][0]["goal_text"] == "do the thing"
+
+    # idea pool mutated: add → update → remove leaves pool empty
+    assert "try it" not in (agent.ideas_dir / "INDEX.md").read_text()
+
+    # execute_python wrote and ran a snippet
+    assert (agent.snippets_dir / "001.py").exists()
+    assert "print('hi')" in (agent.snippets_dir / "001.py").read_text()
+
+    # chat log captured every step (6 assistant turns + 6 tool results = 12 records)
+    records = [json.loads(line) for line in agent.chat_log.read_text().splitlines()]
+    assert len(records) == 12
+    assert [r["name"] for r in records[1::2]] == [
+        "add_idea",
+        "update_idea",
+        "develop",
+        "research",
+        "analyze",
+        "remove_idea",
+    ]
+
+
+def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatch, caplog):
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+    monkeypatch.setattr(main_agent, "call_llm", lambda **kwargs: _fake_text("hello"))
+
+    with caplog.at_level("WARNING"):
+        agent._step([])
+
+    assert any("text-only" in rec.message for rec in caplog.records)
+    records = [json.loads(line) for line in agent.chat_log.read_text().splitlines()]
+    assert len(records) == 1
+    assert records[0]["role"] == "assistant"

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -98,7 +98,7 @@ def get_tools():
     """
     return [
         types.FunctionDeclaration(
-            name="execute_python",
+            name="analyze",
             description="Write and execute a Python script. The script runs in the task data directory with access to all data files, model outputs, and predictions. Print results to stdout.",
             parameters_json_schema={
                 "type": "object",
@@ -334,6 +334,126 @@ def get_explore_tools():
 # ---------------------------------------------------------------------------
 
 
+def get_main_agent_tools():
+    """Get the tool palette available to the Main Agent."""
+    return [
+        types.FunctionDeclaration(
+            name="develop",
+            description=(
+                "Runs one developer iteration and OWNS SUBMISSION AUTHORING: the "
+                "developer subagent writes a `train.py` that produces whatever "
+                "artifact the session goal requires (CSV, ONNX graph, model "
+                "weights, generated text, ZIP bundle, …) and dumps "
+                "`train_stats.json` with a score. Retries internally until "
+                "valid stats land. Returns a structured payload with the final "
+                "code, its path on disk, and a summary (score, stats, "
+                "stdout_tail, attempts_made). Omit `idea_id` on the very first "
+                "call (baseline from the session goal); otherwise pass the "
+                "integer id of the entry you selected from INDEX.md (the "
+                "`[NNN]` prefix) — the framework resolves it to the full "
+                "idea body. DO NOT hand-author submission artifacts yourself "
+                "via `analyze` — that is always wrong; it belongs here."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "idea_id": {
+                        "type": "integer",
+                        "description": "Id of the idea entry to develop (the `[NNN]` prefix in INDEX.md). Omit for baseline.",
+                    },
+                },
+                "required": [],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="research",
+            description=(
+                "Runs one Deep Research iteration: web_fetch + web_search + internal "
+                "Python to produce a markdown report answering the instruction. Use "
+                "for domain grounding, library docs, prior-art sweeps, empirical "
+                "sniff-tests on the dataset."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "instruction": {
+                        "type": "string",
+                        "description": "Free-form research instruction.",
+                    },
+                },
+                "required": ["instruction"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="analyze",
+            description=(
+                "Run a Python snippet in a fresh subprocess for INSPECTION and "
+                "ANALYSIS. Returns stdout/stderr. Legitimate uses: read files, "
+                "inspect artifacts produced by prior `develop` / `research` "
+                "calls, reproduce a reported score, grep code for leakage "
+                "patterns, compute analyses (per-class F1, calibration, "
+                "confusion matrices) over `valid_preds.csv`, list directory "
+                "contents. NOT for authoring submission artifacts (call "
+                "`develop`), NOT for modifying the Python environment "
+                "(`pip install`, `apt`, `conda`), NOT for long training runs. "
+                "If you find yourself iterating variants of a solution via "
+                "this tool, stop and call `develop(idea=...)` instead."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "Complete Python source to execute.",
+                    },
+                },
+                "required": ["code"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="add_idea",
+            description="Add a new entry to the idea pool. Returns the assigned integer id.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Short title — becomes the filename slug and the INDEX.md entry.",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Full markdown body of the idea.",
+                    },
+                },
+                "required": ["title", "description"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="remove_idea",
+            description="Remove an idea from the pool by id.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "idea_id": {"type": "integer"},
+                },
+                "required": ["idea_id"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="update_idea",
+            description="Replace the body of an existing idea. Title stays the same.",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "idea_id": {"type": "integer"},
+                    "description": {"type": "string"},
+                },
+                "required": ["idea_id", "description"],
+            },
+        ),
+    ]
+
+
 def get_developer_tools():
     """Get tools available to the developer agents during code generation."""
     return [
@@ -344,7 +464,7 @@ def get_developer_tools():
                 "packages and get back a markdown report with file:line citations. The "
                 "sub-agent reads source files using read_file/glob_files/grep_code/list_dir "
                 "across configured roots — it does NOT execute Python or shell commands. "
-                "To verify whether a snippet runs, use `execute_python` instead.\n\n"
+                "To verify whether a snippet runs, use `analyze` instead.\n\n"
                 "Use this for static investigation: 'How does X work?', 'What's the "
                 "signature of Y?', 'Where is Z defined?', 'Show me callers of W'. Brief "
                 "the sub-agent like a smart colleague who just walked into the room — it "
@@ -363,7 +483,7 @@ def get_developer_tools():
             },
         ),
         types.FunctionDeclaration(
-            name="execute_python",
+            name="analyze",
             description=(
                 "Run a Python snippet in a fresh subprocess and get back stdout, "
                 "stderr, and the exit code. Use this to VERIFY behavior — test an "


### PR DESCRIPTION
## Summary
Phase 4 of the MainAgent implementation stack (#230). Wires up the top-level LLM-driven orchestrator that replaces the procedural `Orchestrator`. No termination in software — user SIGKILLs when satisfied.

### New files

- **`agents/main_agent.py`** — `MainAgent` class with `__init__(slug, run_id, goal_text)` and `run()`. Core `_step()` method does one function-calling round:
  1. Rebuilds the system prompt each step from `build_system(slug, goal_text, load_index(ideas_dir))` — INDEX.md is always fresh.
  2. `call_llm` with the 6-tool palette.
  3. Dispatches each function call: `develop` → resolves `idea_id` to the file body (`ideas_dir.glob("{NNN}_*.md")`) and passes it to `DeveloperAgent(slug, run_id, dev_iter++, goal_text).run(idea=<body>)`; `research` → `ResearcherAgent(slug, run_id, research_iter++, goal_text).run(instruction)`; `analyze` → writes snippet to `main_agent_snippets/NNN.py` + `execute_code` + returns stdout; `add_idea` / `remove_idea` / `update_idea` → `utils.idea_pool` helpers.
  4. Appends both the assistant content and the function-response content to `input_list`.
  5. Logs every turn (assistant + tool) to `task/<slug>/<run_id>/main_agent_chat.jsonl` as append-only audit.
  6. Text-only responses log a warning and return without dispatching — the system prompt already tells MainAgent "every step should be a tool call", so this is the exception path, not a termination mechanism.
- **`prompts/main_agent.py:build_system(slug, goal_text, index_md)`** — single system-prompt builder. Sections: session goal, current idea pool (INDEX.md inlined with the `develop(idea_id=NNN)` convention spelled out), tool palette with signatures + semantics, **"CRITICAL: verify subagent outputs"** section with concrete verification checklist for `develop` payloads (read the code, check score vs stats, run `analyze` to spot-check valid_preds/leakage patterns), intended rhythm, no-termination note.
- **`tests/test_main_agent.py`** — two tests:
  - `test_dispatches_each_tool` — runs `_step()` six times with mocked `call_llm` emitting each tool in sequence (`add_idea` → `update_idea` → `develop(idea_id=1)` → `research` → `analyze` → `remove_idea`). Asserts: DeveloperAgent/ResearcherAgent each called exactly once with `goal_text` threaded, `develop` receives the full resolved idea body (contains the updated description), idea pool round-trips (add/update/remove leaves pool empty), snippet file written and executed, chat log has 12 records (6 assistant + 6 tool) in the right order.
  - `test_text_only_response_is_logged_and_ignored` — mocked LLM returns a text-only response; asserts a warning is logged and only the assistant record lands in the chat log.

### Modified

- **`utils/llm_utils.py`** — new `get_main_agent_tools()` returning 6 `FunctionDeclaration`s (`develop`, `research`, `analyze`, `add_idea`, `remove_idea`, `update_idea`). `develop` takes `idea_id: int` (optional — omit for baseline); MainAgent's dispatcher is responsible for resolving the id to the full markdown body before handing off to `DeveloperAgent`.
- **`config.yaml`** — new `llm.main_agent_model` entry (same default as the others; separable going forward).

### Why `develop(idea_id: int)` instead of `develop(idea: str)`

INDEX.md (the only idea-pool view the LLM has in its system prompt) contains one-line titles only. If the tool took a free-form `idea: str`, the LLM would pass the title and the developer subagent would see just that one line — the full multi-paragraph description would never reach `codegen_system`'s `<idea>…</idea>` block. Using an integer id forces MainAgent to read the idea file from disk, guaranteeing the developer always sees the complete body.

### Layout on disk during a session

```
task/<slug>/<run_id>/
├── main_agent_chat.jsonl          # append-only audit
├── main_agent_snippets/           # analyze scripts
│   ├── 001.py
│   └── ...
├── ideas/
│   ├── INDEX.md                   # regenerated every mutation
│   └── <id>_<slug-title>.md
├── developer_1/1/…                # from DeveloperAgent per call
├── developer_2/1/…
├── research_1/…                   # from ResearcherAgent per call
└── ...
```

Stacked on top of #239. Phase 5 (orchestrator unstub + `launch_agent.py` CLI entry) lands next.

## Test plan
- [x] `pytest tests/test_main_agent.py -q` → 2 passed.
- [x] `pytest tests/ -q` → 53 passed.
- [x] `python -c "from agents.main_agent import MainAgent; print('ok')"` resolves clean.
- [ ] End-to-end manual run — deferred to Phase 5 (needs `launch_agent.py` wiring + a real GOAL.md + a live slug).
