### PR TITLE
generate description.md from kaggle overview + data pages on agent launch

### DIFF
--- a/launch_agent.py
+++ b/launch_agent.py
@@ -16,7 +16,7 @@ import weave
 
 from agents.main_agent import MainAgent
 from project_config import get_config, get_config_value
-from utils.competition_data import download_competition_data
+from utils.competition_data import download_competition_data, generate_description_md
 
 
 _TASK_ROOT = Path(get_config()["paths"]["task_root"])
@@ -119,6 +119,7 @@ def main() -> None:
 
     try:
         download_competition_data(args.slug, base_dir)
+        generate_description_md(args.slug, base_dir)
         MainAgent(slug=args.slug, run_id=args.run_id, goal_text=goal_text).run()
     finally:
         try:

--- a/utils/competition_data.py
+++ b/utils/competition_data.py
@@ -1,12 +1,14 @@
-"""Download raw Kaggle competition data into ``task/<slug>/``."""
+"""Populate ``task/<slug>/`` from Kaggle: data + description.md."""
 
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from pathlib import Path
 
 from dotenv import load_dotenv
+from firecrawl import Firecrawl
 import kagglehub
 
 logger = logging.getLogger(__name__)
@@ -35,3 +37,40 @@ def download_competition_data(slug: str, target_dir: Path) -> None:
 
     logger.info("Synced competition data for slug=%s from %s to %s",
                 slug, cache_path, target_dir)
+
+
+def generate_description_md(slug: str, target_dir: Path) -> None:
+    """Scrape Kaggle's ``/overview`` + ``/data`` pages into ``description.md``.
+
+    No-op if ``description.md`` already exists under ``target_dir``. Uses
+    Firecrawl (same client the researcher subagent already depends on).
+    Fails loudly on missing ``FIRECRAWL_API_KEY`` / network errors.
+    """
+
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    description_path = target_dir / "description.md"
+    if description_path.exists():
+        return
+
+    load_dotenv()
+    client = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+    overview_url = f"https://www.kaggle.com/competitions/{slug}/overview"
+    data_url = f"https://www.kaggle.com/competitions/{slug}/data"
+
+    overview = client.scrape(overview_url, only_main_content=True, formats=["markdown"])
+    data = client.scrape(data_url, only_main_content=True, formats=["markdown"])
+
+    content = (
+        f"# {slug} — Competition description\n\n"
+        f"## Overview ({overview_url})\n\n"
+        f"{overview.markdown or ''}\n\n"
+        f"---\n\n"
+        f"## Data ({data_url})\n\n"
+        f"{data.markdown or ''}\n"
+    )
+    description_path.write_text(content)
+    logger.info(
+        "Wrote %s for slug=%s (%d chars)", description_path, slug, len(content)
+    )


### PR DESCRIPTION
## Summary
Auto-populates `task/<slug>/description.md` at agent launch by scraping the two Kaggle pages the competition description lives on:

- `https://www.kaggle.com/competitions/<slug>/overview`
- `https://www.kaggle.com/competitions/<slug>/data`

Concatenates them into a single markdown file under section headers and writes it next to the downloaded competition data. Skips the scrape entirely if `description.md` already exists — users who hand-authored one keep it.

### Changes

- **`utils/competition_data.py`** — new `generate_description_md(slug, target_dir)` alongside the existing `download_competition_data`. Uses Firecrawl (same client the researcher subagent already depends on), `only_main_content=True`, `formats=["markdown"]`. Fails loudly on missing `FIRECRAWL_API_KEY` / network / unknown slug — matches the "simple, direct, no fallbacks" direction set for `download_competition_data`.
- **`launch_agent.py`** — calls `generate_description_md(args.slug, base_dir)` immediately after `download_competition_data`, before handing to MainAgent. So MainAgent's very first step already has a populated `task/<slug>/description.md` ready for any `execute_python` / `researcher` call that reaches for it.

### Why this lives at launch, not inside MainAgent

- Scraping is a one-time session-init step, not an in-loop action. Putting it in the CLI keeps MainAgent's system prompt free of a bootstrapping branch.
- Firecrawl usage is already scoped to Researcher + now launch — both orchestration-layer concerns.
- Matches the existing shape: `download_competition_data` → `generate_description_md` → `MainAgent.run()`.

## Test plan
- [x] `python -c "from utils.competition_data import generate_description_md, download_competition_data; print('ok')"` resolves.
- [x] `python launch_agent.py --help` still renders all flags; no new surface.
- [ ] End-to-end: run `launch_agent.py --slug neurogolf-2026` on a clean environment — verify `task/neurogolf-2026/description.md` lands with both sections populated before MainAgent starts. (Deferred — requires FIRECRAWL_API_KEY + a live session.)