### PR TITLE
truncate large tool outputs before they enter the LLM context

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -41,6 +41,7 @@ from tools.helpers import call_llm
 from utils.code_utils import extract_python_code
 from utils.guardrails import build_block_summary, evaluate_guardrails
 from utils.llm_utils import append_message, get_developer_tools
+from utils.output import truncate_for_llm
 
 
 logger = logging.getLogger(__name__)
@@ -215,6 +216,7 @@ class DeveloperAgent:
                 conda_env=self.conda_env,
             )
             (attempt_dir / "train.txt").write_text(output)
+            output = truncate_for_llm(output, attempt_dir / "train.txt")
 
             stats_path = attempt_dir / "train_stats.json"
             if stats_path.exists():
@@ -349,7 +351,7 @@ class DeveloperAgent:
         if function_call.name == "explore_codebase":
             query = args["query"]
             logger.info("explore_codebase called: %s", query[:100])
-            return explore_codebase(query, goal_text=self.goal_text)
+            return truncate_for_llm(explore_codebase(query, goal_text=self.goal_text))
 
         if function_call.name == "analyze":
             code = args["code"]
@@ -366,6 +368,6 @@ class DeveloperAgent:
             script_file = work_dir / f"{step}_{call_idx}.py"
             script_file.write_text(_build_resource_header() + code)
             job = execute_code(str(script_file), timeout_seconds=timeout)
-            return json.dumps({"output": job.result()})
+            return json.dumps({"output": truncate_for_llm(job.result(), script_file.with_suffix(".txt"))})
 
         return json.dumps({"error": f"Unknown tool: {function_call.name}"})

--- a/agents/explorer.py
+++ b/agents/explorer.py
@@ -26,6 +26,7 @@ from project_config import get_config
 from prompts.explore import build_system, build_user
 from tools.helpers import call_llm
 from utils.llm_utils import append_message, get_explore_tools
+from utils.output import truncate_for_llm
 
 
 logger = logging.getLogger(__name__)
@@ -406,7 +407,7 @@ def explore_codebase(query: str, goal_text: str | None = None) -> str:
 
         if not has_function_calls:
             logger.info("Explore completed at step %d", step + 1)
-            return response.text or ""
+            return truncate_for_llm(response.text or "")
 
         function_responses = []
         for part in parts:
@@ -434,4 +435,4 @@ def explore_codebase(query: str, goal_text: str | None = None) -> str:
         messages=input_list,
         enable_google_search=True,
     )
-    return response.text or ""
+    return truncate_for_llm(response.text or "")

--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -28,6 +28,7 @@ from tools.developer import _build_resource_header, execute_code
 from tools.helpers import call_llm
 from utils.idea_pool import add_idea, load_index, remove_idea, update_idea
 from utils.llm_utils import append_message, get_main_agent_tools
+from utils.output import truncate_for_llm
 
 
 _INITIAL_USER_TURN = (
@@ -151,14 +152,14 @@ class MainAgent:
                 research_iter=self.research_iter,
                 goal_text=self.goal_text,
             )
-            return res.run(instruction=args["instruction"])
+            return truncate_for_llm(res.run(instruction=args["instruction"]))
 
         if name == "analyze":
             snippet_num = len(list(self.snippets_dir.glob("*.py"))) + 1
             script_file = self.snippets_dir / f"{snippet_num:03d}.py"
             script_file.write_text(_build_resource_header() + args["code"])
             job = execute_code(str(script_file), timeout_seconds=_EXECUTE_PYTHON_TIMEOUT)
-            return json.dumps({"output": job.result()})
+            return json.dumps({"output": truncate_for_llm(job.result(), script_file.with_suffix(".txt"))})
 
         if name == "add_idea":
             idea_id = add_idea(self.ideas_dir, args["title"], args["description"])

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -8,9 +8,9 @@ It runs a multi-step tool loop over three inner tools — ``web_research``
 ``google_search`` is disabled inside the sub-agent so every URL the LLM
 dereferences is traceable back to a prior tool result (no invented URLs).
 
-No truncation is applied to ``web_research`` / ``web_fetch`` outputs — full
-content flows back to the LLM so the research can go as deep as the step
-budget allows.
+Tool outputs (``web_research``, ``web_fetch``, ``write_python_code``) are
+truncated to 30k chars before flowing back to the LLM. Full content is
+preserved in per-call audit records on disk.
 
 Per-invocation layout (owned by this module):
 
@@ -42,6 +42,7 @@ from prompts.research import build_system, build_user
 from tools.developer import _build_resource_header, execute_code
 from tools.helpers import call_llm
 from utils.llm_utils import append_message, get_deep_research_tools
+from utils.output import truncate_for_llm
 
 
 load_dotenv()
@@ -130,7 +131,7 @@ def _tool_write_python_code(code: str, seq: int, scripts_dir: Path) -> str:
         logger.exception("write_python_code execution failed")
         return json.dumps({"error": f"execution failed: {exc}"})
 
-    return json.dumps({"output": output})
+    return json.dumps({"output": truncate_for_llm(output, script_path.with_suffix(".txt"))})
 
 
 def _render_tool_record_markdown(
@@ -191,13 +192,14 @@ def _execute_tool_call(item, state: dict) -> str:
     else:
         raise ValueError(f"Unknown tool: {tool_name}")
 
+    # Write audit record with FULL result before truncating for the LLM.
     if tool_name in ("web_research", "web_fetch"):
         record_path = state["research_dir"] / tool_name / f"{tool_seq}.md"
         record_path.write_text(
             _render_tool_record_markdown(tool_name, tool_seq, args, result_json)
         )
 
-    return result_json
+    return truncate_for_llm(result_json)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -24,6 +24,7 @@ from prompts.tools_developer import (
     log_monitor_user as prompt_log_monitor_user,
 )
 from schemas.developer import StackTraceSolution, LogMonitorVerdict
+from utils.output import truncate_for_llm
 import weave
 
 load_dotenv()
@@ -76,7 +77,7 @@ def web_search_stack_trace(query: str) -> str:
         text_format=StackTraceSolution,
     )
 
-    return (
+    return truncate_for_llm(
         query
         + "\n"
         + "This is how you can fix the error: \n"

--- a/utils/output.py
+++ b/utils/output.py
@@ -1,0 +1,38 @@
+"""Output truncation for LLM context windows.
+
+Caps tool/execution output at a character limit before it enters the
+conversation thread. When truncated, the full text is optionally persisted
+to a file and the truncated version includes a reference so the LLM can
+read more via ``explore_codebase`` / ``analyze`` if needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MAX_OUTPUT_CHARS = 30_000
+
+
+def truncate_for_llm(
+    text: str,
+    full_output_path: Path | None = None,
+    max_chars: int = MAX_OUTPUT_CHARS,
+) -> str:
+    """Cap *text* for LLM context. Persist full output to disk if over limit.
+
+    If *full_output_path* is given and the file does not already exist, the
+    full text is written there. If it already exists (e.g. the caller wrote
+    ``train.txt`` before calling this), the write is skipped — the path is
+    only used in the truncation reference message.
+    """
+    if len(text) <= max_chars:
+        return text
+    if full_output_path and not full_output_path.exists():
+        full_output_path.parent.mkdir(parents=True, exist_ok=True)
+        full_output_path.write_text(text)
+    total_lines = len(text.splitlines())
+    kept_lines = len(text[:max_chars].splitlines())
+    truncated_lines = total_lines - kept_lines
+    ref = f" Full output: {full_output_path}" if full_output_path else ""
+    return text[:max_chars] + f"\n\n... [{truncated_lines} lines truncated.{ref}]"


### PR DESCRIPTION
## Summary
Adds `utils/output.py:truncate_for_llm(text, full_output_path, max_chars=30_000)` and applies it at all 10 uncapped output flows across the codebase. When output exceeds 30k chars, the full text is persisted to disk (if a path is given and the file doesn't already exist) and the truncated version includes a file reference so the LLM can read more if needed.

## Call sites (10)

| # | Agent | What | Persist path |
|---|---|---|---|
| 1 | DeveloperAgent | `execute_with_monitor` output → retry feedback | `train.txt` (already on disk) |
| 2 | DeveloperAgent | `analyze` tool: `job.result()` | `codegen_snippets/<step>_<call>.txt` (new) |
| 3 | DeveloperAgent | `explore_codebase` report | None (ephemeral) |
| 4 | MainAgent | `analyze` tool: `job.result()` | `main_agent_snippets/<N>.txt` (new) |
| 5 | MainAgent | `research` tool: full markdown report | None (already saved by researcher as `PLAN_N.md`) |
| 6 | ResearcherAgent | `write_python_code`: `job.result()` | `scripts/<N>.txt` (new) |
| 7 | ResearcherAgent | `web_research`: full Exa results | None (audit record on disk) |
| 8 | ResearcherAgent | `web_fetch`: full Firecrawl markdown | None (audit record on disk) |
| 9 | ExplorerAgent | final report return | None (ephemeral) |
| 10 | tools/developer.py | `web_search_stack_trace` return | None (usually small) |

## What the LLM sees

```
INFO:root:Loading model...
INFO:root:Starting inference...

... [847 lines truncated. Full output: task/my-slug/run1/developer_3/2/train.txt]
```

## Test plan
- [x] `python -c "from utils.output import truncate_for_llm; ..."` — imports + truncation logic verified.
- [x] All agent imports clean (`DeveloperAgent`, `MainAgent`, `ResearcherAgent`, `explore_codebase`, `web_search_stack_trace`).