### PR TITLE
wire conversation compaction into MainAgent / DeveloperAgent / ResearcherAgent

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -39,6 +39,7 @@ from tools.developer import (
 )
 from tools.helpers import call_llm
 from utils.code_utils import extract_python_code
+from utils.compact import compact_messages, should_compact
 from utils.guardrails import build_block_summary, evaluate_guardrails
 from utils.llm_utils import append_message, get_developer_tools
 from utils.output import truncate_for_llm
@@ -158,6 +159,7 @@ class DeveloperAgent:
         ]
 
         stderr_cache: dict[str, str | None] = {}
+        last_input_tokens: int | None = None
         k = 0
         while True:
             k += 1
@@ -172,7 +174,9 @@ class DeveloperAgent:
             )
 
             try:
-                code = self._generate_code(input_list, system_prompt, attempt_dir)
+                code, last_input_tokens = self._generate_code(
+                    input_list, system_prompt, attempt_dir, last_input_tokens
+                )
             except Exception as exc:
                 logger.exception(
                     "codegen failed at attempt %d — feeding back and retrying", k
@@ -273,20 +277,25 @@ class DeveloperAgent:
         input_list: list[dict],
         system_prompt: str,
         attempt_dir: Path,
-    ) -> str:
+        last_input_tokens: int | None = None,
+    ) -> tuple[str, int | None]:
         """Inner codegen tool-loop — identical shape to the pre-rewrite version."""
         tools = get_developer_tools()
 
         for step in range(_MAX_CODEGEN_TOOL_STEPS + 1):
             is_last_step = step == _MAX_CODEGEN_TOOL_STEPS
 
-            response = call_llm(
+            if should_compact(last_input_tokens):
+                input_list[:] = compact_messages(input_list, model=_DEVELOPER_MODEL)
+
+            response, last_input_tokens = call_llm(
                 model=_DEVELOPER_MODEL,
                 system_instruction=system_prompt,
                 messages=input_list,
                 text_format=None,
                 function_declarations=tools if not is_last_step else [],
                 enable_google_search=True,
+                include_usage=True,
             )
 
             parts = response.candidates[0].content.parts
@@ -303,7 +312,7 @@ class DeveloperAgent:
                     raise ValueError(
                         "No ```python code block found in model response"
                     )
-                return code
+                return code, last_input_tokens
 
             function_responses = []
             for call_idx, part in enumerate(parts, start=1):

--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -26,6 +26,7 @@ from project_config import get_config
 from prompts.main_agent import build_system
 from tools.developer import _build_resource_header, execute_code
 from tools.helpers import call_llm
+from utils.compact import compact_messages, should_compact
 from utils.idea_pool import add_idea, load_index, remove_idea, update_idea
 from utils.llm_utils import append_message, get_main_agent_tools
 from utils.output import truncate_for_llm
@@ -66,6 +67,7 @@ class MainAgent:
         # send. Subsequent steps accumulate model responses + tool results in
         # this list.
         self.input_list: list[dict] = [append_message("user", _INITIAL_USER_TURN)]
+        self.last_input_tokens: int | None = None
         # Ensure INDEX.md exists so `load_index` has something to read.
         if not (self.ideas_dir / "INDEX.md").exists():
             (self.ideas_dir / "INDEX.md").write_text("# Idea pool\n\n")
@@ -82,12 +84,17 @@ class MainAgent:
             goal_text=self.goal_text,
             index_md=load_index(self.ideas_dir),
         )
-        response = call_llm(
+        if should_compact(self.last_input_tokens):
+            self.input_list = compact_messages(
+                self.input_list, model=_MAIN_AGENT_MODEL
+            )
+        response, self.last_input_tokens = call_llm(
             model=_MAIN_AGENT_MODEL,
             system_instruction=system_prompt,
             messages=self.input_list,
             function_declarations=tools,
             enable_google_search=False,
+            include_usage=True,
         )
 
         parts = response.candidates[0].content.parts

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -41,6 +41,7 @@ from project_config import get_config
 from prompts.research import build_system, build_user
 from tools.developer import _build_resource_header, execute_code
 from tools.helpers import call_llm
+from utils.compact import compact_messages, should_compact
 from utils.llm_utils import append_message, get_deep_research_tools
 from utils.output import truncate_for_llm
 
@@ -265,7 +266,8 @@ class ResearcherAgent:
             "scripts_dir": self.scripts_dir,
             "tool_seq": {},
         }
-        input_list = [append_message("user", user_prompt)]
+        input_list: list[dict] = [append_message("user", user_prompt)]
+        last_input_tokens: int | None = None
 
         markdown = ""
         for step in range(_DEEP_RESEARCH_MAX_STEPS):
@@ -274,12 +276,18 @@ class ResearcherAgent:
                 "ResearcherAgent step %d/%d", step + 1, _DEEP_RESEARCH_MAX_STEPS
             )
 
-            response = call_llm(
+            if should_compact(last_input_tokens):
+                input_list = compact_messages(
+                    input_list, model=_DEEP_RESEARCH_LLM_MODEL
+                )
+
+            response, last_input_tokens = call_llm(
                 model=_DEEP_RESEARCH_LLM_MODEL,
                 system_instruction=system_prompt,
                 function_declarations=tools if not is_last_step else [],
                 messages=input_list,
                 enable_google_search=False,
+                include_usage=True,
             )
 
             parts = response.candidates[0].content.parts
@@ -305,16 +313,26 @@ class ResearcherAgent:
                         )
                     )
 
-            input_list.append(response.candidates[0].content)
+            input_list.append(
+                response.candidates[0].content.model_dump(
+                    mode="json", exclude_none=True
+                )
+            )
             if function_responses:
                 input_list.append(
-                    types.Content(role="function", parts=function_responses)
+                    types.Content(
+                        role="function", parts=function_responses
+                    ).model_dump(mode="json", exclude_none=True)
                 )
         else:
             logger.warning(
                 "ResearcherAgent exhausted %d steps — forcing final report",
                 _DEEP_RESEARCH_MAX_STEPS,
             )
+            if should_compact(last_input_tokens):
+                input_list = compact_messages(
+                    input_list, model=_DEEP_RESEARCH_LLM_MODEL
+                )
             response = call_llm(
                 model=_DEEP_RESEARCH_LLM_MODEL,
                 system_instruction=system_prompt

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,8 @@ runtime:
   write_python_code_timeout_seconds: 300             # Per-call timeout for write_python_code subprocess
   llm_max_retries: 5
   llm_backoff_sequence: [1, 5, 10, 30, 60]
-  max_developer_input_tokens: 250000
+  compaction_threshold_tokens: 200000  # compact when last call's prompt_token_count exceeds this
+  compaction_keep_last: 4               # turns kept verbatim after summary
   directory_listing_max_files: 10
   # Time limits (in seconds)
   baseline_time_limit: 432000  # 5 days for baseline development

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -1,0 +1,104 @@
+"""Unit tests for utils.compact."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from utils import compact
+from utils.compact import compact_messages, should_compact
+
+
+@pytest.fixture(autouse=True)
+def configure_thresholds(monkeypatch):
+    """All tests run against a deterministic threshold + keep-last."""
+    monkeypatch.setattr(
+        compact,
+        "get_config_value",
+        lambda *keys: {
+            ("runtime", "compaction_threshold_tokens"): 100,
+            ("runtime", "compaction_keep_last"): 4,
+        }[keys],
+    )
+
+
+def _msg(role: str, text: str = "x") -> dict:
+    return {"role": role, "parts": [{"text": text}]}
+
+
+def test_should_compact_threshold_boundary():
+    assert should_compact(None) is False
+    assert should_compact(50) is False
+    assert should_compact(100) is False  # strictly greater than
+    assert should_compact(101) is True
+
+
+def test_should_compact_raises_when_threshold_unset(monkeypatch):
+    monkeypatch.setattr(compact, "get_config_value", lambda *_: None)
+    with pytest.raises(RuntimeError, match="compaction_threshold_tokens"):
+        should_compact(999)
+
+
+def test_compact_messages_short_input_is_noop(monkeypatch):
+    """When ≤ keep_last entries exist, the list is returned unchanged."""
+    called = []
+    monkeypatch.setattr(
+        compact, "call_llm", lambda **kw: called.append(kw) or SimpleNamespace(text="x")
+    )
+    msgs = [_msg("user"), _msg("model"), _msg("function"), _msg("user")]
+    out = compact_messages(msgs, model="gemini-3.1-pro-preview")
+    assert out == msgs
+    assert called == []  # no summariser call when nothing to summarise
+
+
+def test_compact_messages_summarises_and_keeps_last_n(monkeypatch):
+    """Happy path: 8-message list → [summary_user, last 4]."""
+    monkeypatch.setattr(
+        compact,
+        "call_llm",
+        lambda **kw: SimpleNamespace(
+            text="<analysis>thinking…</analysis><summary>S1\nS2</summary>"
+        ),
+    )
+    msgs = [
+        _msg("user", "u1"),
+        _msg("model", "m1"),
+        _msg("function", "f1"),
+        _msg("user", "u2"),
+        _msg("model", "m2"),
+        _msg("function", "f2"),
+        _msg("user", "u3"),
+        _msg("model", "m3"),
+    ]
+    out = compact_messages(msgs, model="gemini-3.1-pro-preview")
+
+    # cut = 8 - 4 = 4; kept = msgs[4:] (4 entries); output = [summary, *kept].
+    assert len(out) == 5
+    assert out[0]["role"] == "user"
+    assert "Summary:\nS1\nS2" in out[0]["parts"][0]["text"]
+    assert out[1:] == msgs[4:]
+
+
+def test_compact_messages_summarises_even_when_kept_starts_on_non_user(monkeypatch):
+    """MainAgent shape: only one user (index 0); kept may start on any role."""
+    called = []
+    monkeypatch.setattr(
+        compact,
+        "call_llm",
+        lambda **kw: called.append(kw) or SimpleNamespace(text="<summary>ok</summary>"),
+    )
+    msgs = [
+        _msg("user", "u1"),
+        _msg("model", "m1"),
+        _msg("function", "f1"),
+        _msg("model", "m2"),
+        _msg("function", "f2"),
+    ]
+    out = compact_messages(msgs, model="gemini-3.1-pro-preview")
+
+    # cut = 5 - 4 = 1; kept = msgs[1:] (starts with model — no walk-back).
+    assert len(called) == 1
+    assert len(out) == 5
+    assert out[0]["role"] == "user"
+    assert out[1:] == msgs[1:]

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -60,7 +60,8 @@ def fake_pipeline(monkeypatch, tmp_path):
         captured["system_prompts"].append(system_instruction)
         k = captured["codegen_calls"]
         code = captured["script_factory"](k)
-        return _fake_llm_response(f"Here is the script:\n```python\n{code}\n```\n")
+        response = _fake_llm_response(f"Here is the script:\n```python\n{code}\n```\n")
+        return (response, 0) if kwargs.get("include_usage") else response
 
     monkeypatch.setattr(developer, "call_llm", fake_call_llm)
 

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -111,7 +111,9 @@ def test_dispatches_each_tool(patched_main_agent, monkeypatch):
             _fake_fc("remove_idea", idea_id=1),
         ]
     )
-    monkeypatch.setattr(main_agent, "call_llm", lambda **kwargs: next(responses))
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (next(responses), 0)
+    )
 
     for _ in range(6):
         agent._step([])
@@ -148,7 +150,9 @@ def test_dispatches_each_tool(patched_main_agent, monkeypatch):
 
 def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatch, caplog):
     agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
-    monkeypatch.setattr(main_agent, "call_llm", lambda **kwargs: _fake_text("hello"))
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (_fake_text("hello"), 0)
+    )
 
     with caplog.at_level("WARNING"):
         agent._step([])

--- a/utils/compact.py
+++ b/utils/compact.py
@@ -1,0 +1,165 @@
+"""Conversation compaction for unbounded agent loops.
+
+Triggered after every ``call_llm`` whose returned ``prompt_token_count``
+exceeds ``runtime.compaction_threshold_tokens``. Replaces the front of the
+``input_list`` with a single user-role summary message produced by a
+one-shot Gemini call against the same model the agent is using.
+
+Public API:
+    should_compact(last_input_tokens) -> bool
+    compact_messages(input_list, *, model) -> list[dict]
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from project_config import get_config_value
+from tools.helpers import call_llm
+from utils.llm_utils import append_message
+
+
+logger = logging.getLogger(__name__)
+
+
+_COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
+This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context.
+
+Before providing your final summary, wrap your analysis in <analysis> tags to organize your thoughts and ensure you've covered all necessary points. In your analysis process:
+
+1. Chronologically analyze each message and section of the conversation. For each section thoroughly identify:
+   - The user's explicit requests and intents
+   - Your approach to addressing the user's requests
+   - Key decisions, technical concepts and code patterns
+   - Specific details like:
+     - file names
+     - full code snippets
+     - function signatures
+     - file edits
+   - Errors that you ran into and how you fixed them
+   - Pay special attention to specific user feedback that you received, especially if the user told you to do something differently.
+2. Double-check for technical accuracy and completeness, addressing each required element thoroughly.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: Capture all of the user's explicit requests and intents in detail
+2. Key Technical Concepts: List all important technical concepts, technologies, and frameworks discussed.
+3. Files and Code Sections: Enumerate specific files and code sections examined, modified, or created. Pay special attention to the most recent messages and include full code snippets where applicable and include a summary of why this file read or edit is important.
+4. Errors and fixes: List all errors that you ran into, and how you fixed them. Pay special attention to specific user feedback that you received, especially if the user told you to do something differently.
+5. Problem Solving: Document problems solved and any ongoing troubleshooting efforts.
+6. All user messages: List ALL user messages that are not tool results. These are critical for understanding the users' feedback and changing intent.
+7. Pending Tasks: Outline any pending tasks that you have explicitly been asked to work on.
+8. Current Work: Describe in detail precisely what was being worked on immediately before this summary request, paying special attention to the most recent messages from both user and assistant. Include file names and code snippets where applicable.
+9. Optional Next Step: List the next step that you will take that is related to the most recent work you were doing. IMPORTANT: ensure that this step is DIRECTLY in line with the user's most recent explicit requests, and the task you were working on immediately before this summary request. If your last task was concluded, then only list next steps if they are explicitly in line with the users request. Do not start on tangential requests or really old requests that were already completed without confirming with the user first.
+                       If there is a next step, include direct quotes from the most recent conversation showing exactly what task you were working on and where you left off. This should be verbatim to ensure there's no drift in task interpretation.
+
+Format your output as:
+
+<analysis>
+[Your thought process, ensuring all points are covered thoroughly and accurately]
+</analysis>
+
+<summary>
+1. Primary Request and Intent: ...
+2. Key Technical Concepts: ...
+3. Files and Code Sections: ...
+4. Errors and fixes: ...
+5. Problem Solving: ...
+6. All user messages: ...
+7. Pending Tasks: ...
+8. Current Work: ...
+9. Optional Next Step: ...
+</summary>
+
+The conversation to summarise is provided below inside <conversation> tags as a JSON array of message objects (each with a role and parts). Produce only the <analysis> and <summary> blocks — no other text.
+
+<conversation>
+{conversation_json}
+</conversation>
+"""
+
+
+_SUMMARY_PREAMBLE = (
+    "This session is being continued from a previous conversation that ran out "
+    "of context. The summary below covers the earlier portion of the "
+    "conversation. Continue from where you left off without asking any further "
+    "questions; do not acknowledge the summary or recap what was happening — "
+    "pick up the last task as if the break never happened.\n\n"
+)
+
+
+def should_compact(last_input_tokens: int | None) -> bool:
+    """Return True iff the most recent call's prompt_token_count exceeds the configured threshold."""
+    if last_input_tokens is None:
+        return False
+    threshold = get_config_value("runtime", "compaction_threshold_tokens")
+    if threshold is None:
+        raise RuntimeError(
+            "config.yaml is missing required key runtime.compaction_threshold_tokens"
+        )
+    over = last_input_tokens > int(threshold)
+    logger.info(
+        "[compact] input_tokens=%d threshold=%d → %s",
+        last_input_tokens,
+        int(threshold),
+        "COMPACTING" if over else "ok",
+    )
+    return over
+
+
+def compact_messages(input_list: list[dict], *, model: str) -> list[dict]:
+    """Summarise the front of ``input_list`` and return ``[summary_user, *kept]``.
+
+    ``kept`` is the last ``runtime.compaction_keep_last`` entries. Gemini's
+    "conversation must start with user" rule is satisfied by the prepended
+    ``summary_user`` turn, so ``kept`` may start on any role — including an
+    orphaned function-response whose function_call was summarised away.
+    """
+    keep_last = get_config_value("runtime", "compaction_keep_last")
+    if keep_last is None:
+        raise RuntimeError(
+            "config.yaml is missing required key runtime.compaction_keep_last"
+        )
+    keep_last = int(keep_last)
+
+    if len(input_list) <= keep_last:
+        return list(input_list)
+
+    cut = len(input_list) - keep_last
+    old, recent = input_list[:cut], input_list[cut:]
+
+    logger.info(
+        "[compact] summarising %d old messages, keeping %d verbatim",
+        len(old),
+        len(recent),
+    )
+
+    response = call_llm(
+        model=model,
+        system_instruction="You are summarising a tool-driven agent conversation.",
+        messages=_COMPACT_PROMPT.format(
+            conversation_json=json.dumps(old, ensure_ascii=False)
+        ),
+        function_declarations=None,
+        enable_google_search=False,
+    )
+    summary_text = _format_summary((response.text or "").strip())
+    summary_msg = append_message("user", _SUMMARY_PREAMBLE + summary_text)
+    return [summary_msg, *recent]
+
+
+_ANALYSIS_RE = re.compile(r"<analysis>[\s\S]*?</analysis>")
+_SUMMARY_RE = re.compile(r"<summary>([\s\S]*?)</summary>")
+
+
+def _format_summary(raw: str) -> str:
+    """Strip <analysis>; unwrap <summary>…</summary> into a `Summary:` header."""
+    formatted = _ANALYSIS_RE.sub("", raw)
+    match = _SUMMARY_RE.search(formatted)
+    if match:
+        formatted = _SUMMARY_RE.sub(
+            f"Summary:\n{match.group(1).strip()}", formatted, count=1
+        )
+    return re.sub(r"\n\n+", "\n\n", formatted).strip() or raw


### PR DESCRIPTION
## Summary
Adds `utils/compact.py` (`should_compact`, `compact_messages`) and wires it into MainAgent / DeveloperAgent / ResearcherAgent. After every `call_llm` with `include_usage=True`, the caller checks `should_compact(last_input_tokens)` against `runtime.compaction_threshold_tokens`; if over, the front of `input_list` is replaced by a single user-role summary turn produced by a one-shot Gemini call against the same model the agent is using.

### How `compact_messages` chooses the cut point

`kept = input_list[-keep_last:]` where `keep_last = runtime.compaction_keep_last`. The kept suffix may start on any role (user, model, function) — Gemini's "conversation must start with a user turn" requirement is satisfied by the prepended `summary_user` message, not by the shape of `kept`. See `demos/compact_first_msg_test.py` for the empirical check that Gemini tolerates an orphaned `function` (parent `function_call` summarised away) when a user turn precedes it.

### Why no walk-back

An earlier revision tried to slide `cut` backward until it landed on a user-role message, on the assumption that `kept` itself had to start with user. In MainAgent that produced a hard no-op: MainAgent's `input_list` has exactly ONE user turn (index 0, the initial kick-off), so `cut` always walked to 0 and nothing ever got summarised. The demo above confirmed the walk-back was unnecessary.

### Summary prompt

`_COMPACT_PROMPT` adapts Claude Code's compaction template — nine-section structured summary (Primary Request, Technical Concepts, Files + Code, Errors + Fixes, Problem Solving, All User Messages, Pending Tasks, Current Work, Optional Next Step) wrapped in `<analysis>` + `<summary>` tags. `_format_summary` strips `<analysis>` and unwraps `<summary>…</summary>` into a `Summary:`-prefixed user turn.

### Files
- **`utils/compact.py`** — `should_compact`, `compact_messages`, `_COMPACT_PROMPT`, `_SUMMARY_PREAMBLE`.
- **`agents/main_agent.py`** — threads `last_input_tokens` through `_step`; calls `should_compact` + `compact_messages` at the top of each step.
- **`agents/developer.py`** — same pattern inside `_generate_code`'s tool loop.
- **`agents/researcher.py`** — same pattern inside the deep-research tool loop (both the normal path and the force-final-report fallback).
- **`tools/helpers.py`** — `call_llm` gains `include_usage: bool` and returns `(response, input_tokens)` when set.
- **`tests/test_compact.py`** — unit tests for threshold boundary + MainAgent shape (one user at index 0, kept may start on any role).
- **`config.yaml`** — `runtime.compaction_threshold_tokens` and `runtime.compaction_keep_last`.

## Test plan
- [x] `pytest tests/test_compact.py -q` → 5 passed.
- [x] `pytest tests/ -q` → 58 passed.
- [ ] End-to-end: restart the `neurogolf-2026` session with a realistic threshold; confirm the `[compact] summarising N old messages, keeping M verbatim` log fires and the token count drops after the next `call_llm`.
