### PR TITLE
unthread goal from subagents; infinite tool loops; drop dead configs

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -1,11 +1,11 @@
 """Developer subagent — one training iteration per call.
 
 Parallel to ``ResearcherAgent`` in shape: construct with
-``(slug, run_id, dev_iter, goal_text, conda_env)`` and call ``run(idea)`` to
-produce one training iteration worth of artifacts. An unbounded internal
-retry loop iterates attempts (``developer_<dev_iter>/<k>/``) until one
-produces a valid ``train_stats.json``; the subagent only exits on success
-or a runtime precondition failure that happens before the loop starts.
+``(slug, run_id, dev_iter, conda_env)`` and call ``run(idea)`` to produce
+one training iteration worth of artifacts. An unbounded internal retry
+loop iterates attempts (``developer_<dev_iter>/<k>/``) until one produces
+a valid ``train_stats.json``; the subagent only exits on success or a
+runtime precondition failure that happens before the loop starts.
 
 Evaluation is the developer's responsibility — the generated ``train.py``
 computes its own score and writes ``train_stats.json`` at end-of-run.
@@ -63,7 +63,6 @@ _ENABLE_LOGGING_GUARD = bool(_GUARDRAIL_CFG["logging_basicconfig_order"])
 _ENABLE_LEAKAGE_GUARD = bool(_GUARDRAIL_CFG["leakage_review"])
 _ENABLE_CODE_SAFETY = bool(_GUARDRAIL_CFG["enable_code_safety"])
 
-_MAX_CODEGEN_TOOL_STEPS = 100
 _STDOUT_TAIL_LINES = 200
 
 
@@ -98,10 +97,11 @@ class DeveloperAgent:
     """One-training-iteration subagent.
 
     Parallel to ``Orchestrator`` / ``ResearcherAgent`` in shape. Construct
-    with the per-call identity (``slug``, ``run_id``, ``dev_iter``, the
-    session's ``goal_text`` from ``GOAL.md``, and an optional ``conda_env``),
-    then call ``run(idea)``. Returns a structured payload describing success
-    or precondition failure.
+    with the per-call identity (``slug``, ``run_id``, ``dev_iter``, and an
+    optional ``conda_env``), then call ``run(idea)``. Returns a structured
+    payload describing success or precondition failure. The caller is
+    responsible for passing a self-sufficient ``idea`` string — the
+    developer does not see the session goal directly.
     """
 
     def __init__(
@@ -109,13 +109,11 @@ class DeveloperAgent:
         slug: str,
         run_id: str,
         dev_iter: int,
-        goal_text: str,
         conda_env: str | None = None,
     ):
         self.slug = slug
         self.run_id = run_id
         self.dev_iter = dev_iter
-        self.goal_text = goal_text
         self.conda_env = conda_env
         self.base_dir = _TASK_ROOT / slug / run_id / f"developer_{dev_iter}"
         self.base_dir.mkdir(parents=True, exist_ok=True)
@@ -145,11 +143,10 @@ class DeveloperAgent:
         return None
 
     @weave.op()
-    def run(self, idea: str | None = None) -> dict[str, Any]:
+    def run(self, idea: str) -> dict[str, Any]:
         """Run one developer iteration; retry on failure until success."""
         previous_code = self._find_previous_code()
         system_prompt = codegen_system(
-            goal_text=self.goal_text,
             idea=idea,
             previous_code=previous_code,
         )
@@ -279,11 +276,12 @@ class DeveloperAgent:
         attempt_dir: Path,
         last_input_tokens: int | None = None,
     ) -> tuple[str, int | None]:
-        """Inner codegen tool-loop — identical shape to the pre-rewrite version."""
+        """Inner codegen tool-loop — runs until the model emits a text response with a code block."""
         tools = get_developer_tools()
+        step = 0
 
-        for step in range(_MAX_CODEGEN_TOOL_STEPS + 1):
-            is_last_step = step == _MAX_CODEGEN_TOOL_STEPS
+        while True:
+            step += 1
 
             if should_compact(last_input_tokens):
                 input_list[:] = compact_messages(input_list, model=_DEVELOPER_MODEL)
@@ -293,7 +291,7 @@ class DeveloperAgent:
                 system_instruction=system_prompt,
                 messages=input_list,
                 text_format=None,
-                function_declarations=tools if not is_last_step else [],
+                function_declarations=tools,
                 enable_google_search=True,
                 include_usage=True,
             )
@@ -320,7 +318,7 @@ class DeveloperAgent:
                     tool_result_str = self._execute_developer_tool_call(
                         part.function_call,
                         attempt_dir=attempt_dir,
-                        step=step + 1,
+                        step=step,
                         call_idx=call_idx,
                     )
                     function_responses.append(
@@ -342,10 +340,6 @@ class DeveloperAgent:
                     ).model_dump(mode="json", exclude_none=True)
                 )
 
-        raise RuntimeError(
-            "Code generation exhausted tool steps without producing code"
-        )
-
     def _execute_developer_tool_call(
         self,
         function_call,
@@ -360,7 +354,7 @@ class DeveloperAgent:
         if function_call.name == "explore_codebase":
             query = args["query"]
             logger.info("explore_codebase called: %s", query[:100])
-            return truncate_for_llm(explore_codebase(query, goal_text=self.goal_text))
+            return truncate_for_llm(explore_codebase(query))
 
         if function_call.name == "analyze":
             code = args["code"]

--- a/agents/explorer.py
+++ b/agents/explorer.py
@@ -36,7 +36,6 @@ _CONFIG = get_config()
 _LLM_CFG = _CONFIG["llm"]
 _RUNTIME_CFG = _CONFIG["runtime"]
 _DEVELOPER_TOOL_MODEL = _LLM_CFG["developer_tool_model"]
-_MAX_STEPS = _RUNTIME_CFG["explore_max_steps"]
 
 _USER_ROOTS = [Path(r).resolve() for r in _RUNTIME_CFG["explore_allowed_roots"]]
 _SITE_PACKAGES = Path(sysconfig.get_path("purelib")).resolve()
@@ -369,13 +368,11 @@ def _execute_tool_call(item) -> str:
 
 
 @weave.op()
-def explore_codebase(query: str, goal_text: str | None = None) -> str:
+def explore_codebase(query: str) -> str:
     """Run the codebase exploration sub-agent and return a markdown report.
 
     Args:
         query: Natural language question about the codebase or libraries.
-        goal_text: Optional session-level objective (from GOAL.md) — inlined
-            into the subagent's system prompt under ``# Session Goal``.
 
     Returns:
         Free-form markdown report (with file:line citations).
@@ -383,19 +380,20 @@ def explore_codebase(query: str, goal_text: str | None = None) -> str:
     logger.info("Starting codebase exploration: %s", query[:100])
 
     allowed_roots_display = [str(r) for r in _ALLOWED_ROOTS]
-    system_prompt = build_system(allowed_roots_display, goal_text=goal_text)
+    system_prompt = build_system(allowed_roots_display)
     user_prompt = build_user(query)
     tools = get_explore_tools()
     input_list = [append_message("user", user_prompt)]
 
-    for step in range(_MAX_STEPS):
-        is_last_step = step == _MAX_STEPS - 1
-        logger.info("Explore step %d/%d", step + 1, _MAX_STEPS)
+    step = 0
+    while True:
+        step += 1
+        logger.info("Explore step %d", step)
 
         response = call_llm(
             model=_DEVELOPER_TOOL_MODEL,
             system_instruction=system_prompt,
-            function_declarations=tools if not is_last_step else [],
+            function_declarations=tools,
             messages=input_list,
             enable_google_search=True,
         )
@@ -406,7 +404,7 @@ def explore_codebase(query: str, goal_text: str | None = None) -> str:
         )
 
         if not has_function_calls:
-            logger.info("Explore completed at step %d", step + 1)
+            logger.info("Explore completed at step %d", step)
             return truncate_for_llm(response.text or "")
 
         function_responses = []
@@ -425,14 +423,3 @@ def explore_codebase(query: str, goal_text: str | None = None) -> str:
             input_list.append(
                 types.Content(role="function", parts=function_responses)
             )
-
-    # Exhausted steps — force a final text response
-    logger.warning("Explore exhausted %d steps, forcing final report", _MAX_STEPS)
-    response = call_llm(
-        model=_DEVELOPER_TOOL_MODEL,
-        system_instruction=system_prompt
-        + "\n\nReturn your findings now based on what you have gathered.",
-        messages=input_list,
-        enable_google_search=True,
-    )
-    return truncate_for_llm(response.text or "")

--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -5,8 +5,9 @@ step: `developer` / `researcher` (subagents), `analyze` (leaf), and
 memory ops (`add_idea` / `remove_idea` / `update_idea`). No termination in
 software — user SIGKILLs the process when satisfied.
 
-Session-level context: `GOAL.md` (threaded into every subagent's system
-prompt) and `task/<slug>/<run_id>/ideas/INDEX.md` (always-resident, regenerated
+Session-level context: `GOAL.md` (only in MainAgent's own system prompt —
+subagents receive task-scoped strings via `idea` / `instruction` / `query`)
+and `task/<slug>/<run_id>/ideas/INDEX.md` (always-resident, regenerated
 after every idea-pool mutation).
 """
 
@@ -134,19 +135,19 @@ class MainAgent:
 
     def _dispatch(self, name: str, args: dict) -> str:
         if name == "develop":
-            idea_text: str | None = None
             if "idea_id" in args:
                 idea_id = int(args["idea_id"])
                 matches = list(self.ideas_dir.glob(f"{idea_id:03d}_*.md"))
                 if not matches:
                     return json.dumps({"error": f"unknown idea_id: {idea_id}"})
                 idea_text = matches[0].read_text()
+            else:
+                idea_text = self.goal_text
             self.dev_iter += 1
             dev = DeveloperAgent(
                 slug=self.slug,
                 run_id=self.run_id,
                 dev_iter=self.dev_iter,
-                goal_text=self.goal_text,
             )
             payload = dev.run(idea=idea_text)
             return json.dumps(payload)
@@ -157,7 +158,6 @@ class MainAgent:
                 slug=self.slug,
                 run_id=self.run_id,
                 research_iter=self.research_iter,
-                goal_text=self.goal_text,
             )
             return truncate_for_llm(res.run(instruction=args["instruction"]))
 

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -58,7 +58,6 @@ _PATH_CFG = _CONFIG["paths"]
 
 _TASK_ROOT = Path(_PATH_CFG["task_root"])
 _DEEP_RESEARCH_LLM_MODEL = _LLM_CFG["developer_tool_model"]
-_DEEP_RESEARCH_MAX_STEPS = _RUNTIME_CFG["deep_research_max_steps"]
 _WRITE_PYTHON_CODE_TIMEOUT_SECONDS = _RUNTIME_CFG["write_python_code_timeout_seconds"]
 
 
@@ -221,12 +220,10 @@ class ResearcherAgent:
         slug: str,
         run_id: str,
         research_iter: int,
-        goal_text: str | None = None,
     ):
         self.slug = slug
         self.run_id = run_id
         self.research_iter = research_iter
-        self.goal_text = goal_text
         self.research_dir = _TASK_ROOT / slug / run_id / f"research_{research_iter}"
         self.scripts_dir = self.research_dir / "scripts"
         self.web_research_dir = self.research_dir / "web_research"
@@ -258,7 +255,7 @@ class ResearcherAgent:
             instruction,
         )
 
-        system_prompt = build_system(goal_text=self.goal_text)
+        system_prompt = build_system()
         user_prompt = build_user(instruction)
         tools = get_deep_research_tools()
         state: dict = {
@@ -270,11 +267,10 @@ class ResearcherAgent:
         last_input_tokens: int | None = None
 
         markdown = ""
-        for step in range(_DEEP_RESEARCH_MAX_STEPS):
-            is_last_step = step == _DEEP_RESEARCH_MAX_STEPS - 1
-            logger.info(
-                "ResearcherAgent step %d/%d", step + 1, _DEEP_RESEARCH_MAX_STEPS
-            )
+        step = 0
+        while True:
+            step += 1
+            logger.info("ResearcherAgent step %d", step)
 
             if should_compact(last_input_tokens):
                 input_list = compact_messages(
@@ -284,7 +280,7 @@ class ResearcherAgent:
             response, last_input_tokens = call_llm(
                 model=_DEEP_RESEARCH_LLM_MODEL,
                 system_instruction=system_prompt,
-                function_declarations=tools if not is_last_step else [],
+                function_declarations=tools,
                 messages=input_list,
                 enable_google_search=False,
                 include_usage=True,
@@ -298,7 +294,7 @@ class ResearcherAgent:
             )
 
             if not has_function_calls:
-                logger.info("ResearcherAgent completed at step %d", step + 1)
+                logger.info("ResearcherAgent completed at step %d", step)
                 markdown = response.text or ""
                 break
 
@@ -324,23 +320,6 @@ class ResearcherAgent:
                         role="function", parts=function_responses
                     ).model_dump(mode="json", exclude_none=True)
                 )
-        else:
-            logger.warning(
-                "ResearcherAgent exhausted %d steps — forcing final report",
-                _DEEP_RESEARCH_MAX_STEPS,
-            )
-            if should_compact(last_input_tokens):
-                input_list = compact_messages(
-                    input_list, model=_DEEP_RESEARCH_LLM_MODEL
-                )
-            response = call_llm(
-                model=_DEEP_RESEARCH_LLM_MODEL,
-                system_instruction=system_prompt
-                + "\n\nReturn your final markdown report now, based on everything you have gathered.",
-                messages=input_list,
-                enable_google_search=False,
-            )
-            markdown = response.text or ""
 
         plan_path = self.research_dir / f"PLAN_{self.research_iter}.md"
         plan_path.write_text(markdown)

--- a/config.yaml
+++ b/config.yaml
@@ -4,22 +4,14 @@ llm:
   developer_tool_model: "gemini-3.1-pro-preview"
   leakage_review_model: "gemini-3.1-pro-preview"
 runtime:
-  # Deep Research sub-agent
-  deep_research_max_steps: 512                       # Max tool-call rounds per deep_research invocation
   write_python_code_timeout_seconds: 300             # Per-call timeout for write_python_code subprocess
   llm_max_retries: 5
   llm_backoff_sequence: [1, 5, 10, 30, 60]
   compaction_threshold_tokens: 200000  # compact when last call's prompt_token_count exceeds this
   compaction_keep_last: 4               # turns kept verbatim after summary
-  directory_listing_max_files: 10
-  # Time limits (in seconds)
-  baseline_time_limit: 432000  # 5 days for baseline development
   baseline_code_timeout: 43200  # 12 hours for baseline code execution
   log_monitor_interval: 120  # Seconds between LLM log monitor calls during code execution
-  is_lower_better: false  # Metric direction: true if lower scores are better (e.g. MSE), false if higher is better (e.g. R²)
-  gold_threshold: null  # Target score to reach (null = no target)
   # Codebase exploration sub-agent
-  explore_max_steps: 100  # Max tool-call rounds the explore subagent can use per invocation
   explore_allowed_roots:
     # Paths the explore subagent is allowed to read.
     # The site-packages directory of the active Python interpreter (i.e. whichever
@@ -30,7 +22,6 @@ runtime:
     - /workspace
 paths:
   task_root: "task"
-  external_data_dirname: "external-data"
 guardrails:
   logging_basicconfig_order: true
   leakage_review: true

--- a/prompts/developer.py
+++ b/prompts/developer.py
@@ -13,13 +13,10 @@ from pathlib import Path
 
 
 def codegen_system(
-    goal_text: str,
-    idea: str | None = None,
+    idea: str,
     previous_code: str | None = None,
 ) -> str:
-    idea_section = ""
-    if idea:
-        idea_section = f"\n<idea>\n{idea}\n</idea>\n"
+    idea_section = f"\n<idea>\n{idea}\n</idea>\n"
 
     previous_section = ""
     if previous_code:
@@ -33,11 +30,7 @@ def codegen_system(
             "</previous_code>\n"
         )
 
-    return f"""You are a developer producing a single Python script (`train.py`) that completes one training iteration toward the session goal below. Output one complete script per attempt; the previous attempt's code and any failure feedback are visible above in the conversation thread.
-
-<goal>
-{goal_text}
-</goal>
+    return f"""You are a developer producing a single Python script (`train.py`) that implements the task specified by the `<idea>` block below. Output one complete script per attempt; the previous attempt's code and any failure feedback are visible above in the conversation thread.
 {idea_section}{previous_section}
 ## Hard constraints
 

--- a/prompts/explore.py
+++ b/prompts/explore.py
@@ -7,20 +7,9 @@ and the tools the agent has access to are also read-only.
 from __future__ import annotations
 
 
-def build_system(allowed_roots: list[str], goal_text: str | None = None) -> str:
+def build_system(allowed_roots: list[str]) -> str:
     roots_block = "\n".join(f"- {r}" for r in allowed_roots)
-    goal_section = ""
-    if goal_text:
-        goal_section = f"""
-
-# Session Goal
-
-{goal_text}
-
----
-"""
     return f"""You are a codebase exploration specialist. You excel at thoroughly navigating and exploring source code to answer questions for the agent that called you.
-{goal_section}
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
 This is a READ-ONLY exploration task. You are STRICTLY PROHIBITED from:

--- a/prompts/research.py
+++ b/prompts/research.py
@@ -10,20 +10,8 @@ originate from a prior tool result (no model-authored URLs).
 from __future__ import annotations
 
 
-def build_system(goal_text: str | None = None) -> str:
-    goal_section = ""
-    if goal_text:
-        goal_section = f"""
-
-# Session Goal
-
-{goal_text}
-
----
-"""
-
-    return f"""You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
-{goal_section}
+def build_system() -> str:
+    return """You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
 
 === CRITICAL: READ-ONLY MODE ===
 You may not modify, create, or delete files outside of `write_python_code`'s scratch directory. You have no Edit/Write tools — attempting any is a bug.

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -104,9 +104,8 @@ def test_success_on_first_attempt(fake_pipeline, tmp_path):
         slug="test-slug",
         run_id="r1",
         dev_iter=1,
-        goal_text="Produce a finite score.",
     )
-    payload = dev.run(idea=None)
+    payload = dev.run(idea="Produce a finite score.")
 
     assert payload["status"] == "success"
     assert payload["summary"]["attempts_made"] == 1
@@ -132,9 +131,8 @@ def test_retries_until_stats_written(fake_pipeline, tmp_path):
         slug="test-slug",
         run_id="r1",
         dev_iter=1,
-        goal_text="Produce a finite score.",
     )
-    payload = dev.run(idea=None)
+    payload = dev.run(idea="Produce a finite score.")
 
     assert payload["status"] == "success"
     assert payload["summary"]["attempts_made"] == 2
@@ -176,9 +174,8 @@ def test_guardrails_block_counts_as_failed_attempt(monkeypatch, fake_pipeline, t
         slug="test-slug",
         run_id="r1",
         dev_iter=1,
-        goal_text="Produce a finite score.",
     )
-    payload = dev.run(idea=None)
+    payload = dev.run(idea="Produce a finite score.")
 
     assert payload["status"] == "success"
     assert payload["summary"]["attempts_made"] == 2
@@ -201,7 +198,6 @@ def test_previous_code_threaded_into_system_prompt(fake_pipeline, tmp_path):
         slug="test-slug",
         run_id="r1",
         dev_iter=2,
-        goal_text="Improve the prior run.",
     )
     payload = dev.run(idea="try a bigger model")
 

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -49,13 +49,12 @@ def patched_main_agent(monkeypatch, tmp_path):
     dev_calls: list = []
 
     class FakeDeveloperAgent:
-        def __init__(self, slug, run_id, dev_iter, goal_text):
+        def __init__(self, slug, run_id, dev_iter):
             dev_calls.append(
                 {
                     "slug": slug,
                     "run_id": run_id,
                     "dev_iter": dev_iter,
-                    "goal_text": goal_text,
                 }
             )
             self.dev_iter = dev_iter
@@ -80,13 +79,12 @@ def patched_main_agent(monkeypatch, tmp_path):
     research_calls: list = []
 
     class FakeResearcherAgent:
-        def __init__(self, slug, run_id, research_iter, goal_text):
+        def __init__(self, slug, run_id, research_iter):
             research_calls.append(
                 {
                     "slug": slug,
                     "run_id": run_id,
                     "research_iter": research_iter,
-                    "goal_text": goal_text,
                 }
             )
 
@@ -118,15 +116,13 @@ def test_dispatches_each_tool(patched_main_agent, monkeypatch):
     for _ in range(6):
         agent._step([])
 
-    # developer + researcher subagents invoked once each with threaded goal_text
+    # developer + researcher subagents invoked once each
     assert len(patched_main_agent["dev_calls"]) == 1
-    assert patched_main_agent["dev_calls"][0]["goal_text"] == "do the thing"
     assert patched_main_agent["dev_calls"][0]["dev_iter"] == 1
     # develop resolved idea_id=1 → full file body (includes the updated description "body v2")
     assert "body v2" in patched_main_agent["dev_calls"][0]["idea"]
     assert len(patched_main_agent["research_calls"]) == 1
     assert patched_main_agent["research_calls"][0]["research_iter"] == 1
-    assert patched_main_agent["research_calls"][0]["goal_text"] == "do the thing"
 
     # idea pool mutated: add → update → remove leaves pool empty
     assert "try it" not in (agent.ideas_dir / "INDEX.md").read_text()
@@ -146,6 +142,20 @@ def test_dispatches_each_tool(patched_main_agent, monkeypatch):
         "analyze",
         "remove_idea",
     ]
+
+
+def test_baseline_develop_passes_goal_as_idea(patched_main_agent, monkeypatch):
+    """`develop()` with no idea_id falls through to idea=<goal_text>."""
+    agent = MainAgent(slug="test", run_id="r1", goal_text="the session goal body")
+    responses = iter([_fake_fc("develop")])
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (next(responses), 0)
+    )
+
+    agent._step([])
+
+    assert len(patched_main_agent["dev_calls"]) == 1
+    assert patched_main_agent["dev_calls"][0]["idea"] == "the session goal body"
 
 
 def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatch, caplog):

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -43,7 +43,6 @@ _CONFIG = get_config()
 _LLM_CFG = _CONFIG["llm"]
 _DEVELOPER_TOOL_MODEL = _LLM_CFG["developer_tool_model"]
 _RUNTIME_CFG = _CONFIG["runtime"]
-_BASELINE_TIME_LIMIT = _RUNTIME_CFG["baseline_time_limit"]
 _BASELINE_CODE_TIMEOUT = _RUNTIME_CFG["baseline_code_timeout"]
 _LOG_MONITOR_INTERVAL = _RUNTIME_CFG["log_monitor_interval"]
 

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,7 +1,5 @@
 import json
 import logging
-import os
-import re
 import time
 
 from google import genai
@@ -104,57 +102,6 @@ def _retry_with_backoff(func, *, max_retries, backoff_sequence):
             raise
 
     raise last_exception
-
-
-_RUN_ID_PATTERN = re.compile(r"^\d{8}_\d{6}$")
-
-
-def _build_directory_listing(root: str, num_files: int | None = None) -> str:
-    cfg = get_config()
-    runtime_cfg = cfg["runtime"]
-    limit = (
-        num_files
-        if num_files is not None
-        else runtime_cfg["directory_listing_max_files"]
-    )
-    lines: list[str] = []
-
-    for current_root, dirs, files in os.walk(root):
-        rel_root = os.path.relpath(current_root, root)
-
-        # Determine traversal policy for the run_id tree: allow only external_data/ contents
-        segments = [] if rel_root in (".", "") else rel_root.split(os.sep)
-        files_to_show = files
-
-        if segments and _RUN_ID_PATTERN.match(segments[0]):
-            # At <root>/<run_id>
-            if len(segments) == 1:
-                # Only descend into external_data; hide per-iteration noise
-                dirs[:] = sorted([d for d in dirs if d == "external_data"])
-                files_to_show = []
-            else:
-                # At or below <root>/<run_id>/*
-                if segments[1] == "external_data":
-                    dirs[:] = sorted(dirs)
-                    files_to_show = files
-                else:
-                    dirs[:] = []
-                    files_to_show = []
-        else:
-            dirs[:] = sorted(dirs)
-            files_to_show = files
-
-        depth = 0 if rel_root in (".", "") else rel_root.count(os.sep) + 1
-        indent = "    " * depth
-        folder_display = "." if rel_root in (".", "") else os.path.basename(rel_root)
-        lines.append(f"{indent}{folder_display}/")
-
-        for name in files_to_show[:limit]:
-            lines.append(f"{indent}    {name}")
-        if len(files_to_show) > limit:
-            lines.append(f"{indent}    ... ({len(files_to_show) - limit} more files)")
-
-    return "\n".join(lines)
 
 
 @weave.op()


### PR DESCRIPTION
## Summary

Three entangled cleanups on top of #245:

1. **Unthread `goal_text` from subagents.** `GOAL.md` no longer gets inlined into `DeveloperAgent`, `ResearcherAgent`, or `explore_codebase` system prompts. Only `MainAgent` holds the goal. Subagents operate on a task-scoped string: `idea` / `instruction` / `query`.
2. **Make all tool loops infinite.** `DeveloperAgent._generate_code`, `ResearcherAgent.run`, and `explore_codebase` now loop `while True`, exiting only when the LLM emits a text response. The arbitrary step caps (100 / 512 / 100) and their "force a final report" fallbacks are gone.
3. **Drop dead configs + their consumers.** Audited `config.yaml` for keys with no live reader.

## Why

Trace `019da3b2` (`MainAgent.run` on `neurogolf-2026`) showed 143 `analyze` calls across 3 developer iterations and the main loop. Inspecting the developer's codegen snippets (e.g. `developer_1/1/codegen_snippets/30_1.py`, `40_1.py`) revealed the developer authoring full `nn.Module` + `torch.onnx.export` prototypes inside its tool loop. Root cause: the developer's system prompt inlined the session goal, tempting it to design the whole solution end-to-end rather than implement the narrow `<idea>` block. Unthreading the goal keeps subagents scoped; MainAgent remains the single place that reasons about the overall goal.

The step caps in the three subagent loops were never load-bearing — the loops exit naturally when the LLM stops emitting `function_call`. The caps just added `is_last_step` plumbing (strip tools on the final step to force a text response) and a force-final-report fallback that duplicated the exit contract.

## Changes

### §1 — Unthread goal

- `agents/developer.py`: drop `goal_text` from `DeveloperAgent.__init__`; drop from `codegen_system(...)` and `explore_codebase(query)` calls; `run(idea: str)` now requires `idea` (no default).
- `agents/researcher.py`: drop `goal_text` from `ResearcherAgent.__init__`; `build_system()` call drops the arg.
- `agents/explorer.py`: drop `goal_text` from `explore_codebase(query)` signature; drop from `build_system(...)` call.
- `agents/main_agent.py`: drop `goal_text=` from the `DeveloperAgent(...)` and `ResearcherAgent(...)` constructors. In `_dispatch` for `develop`: when `idea_id` is absent, fall back to `idea_text = self.goal_text` so the baseline case sends the goal as the idea.
- `prompts/developer.py`: `codegen_system(idea: str, previous_code=None)` — `idea` is now required; delete the `<goal>` block; rewrite opener to "specified by the `<idea>` block below".
- `prompts/research.py`, `prompts/explore.py`: drop `goal_text` param and the conditional `# Session Goal` section.
- Tests updated to match.

### §2 — Infinite tool loops

- `agents/developer.py`: `_generate_code` now `while True: step += 1`; always passes `function_declarations=tools`; deleted trailing `raise RuntimeError("… exhausted tool steps …")` and `_MAX_CODEGEN_TOOL_STEPS = 100`.
- `agents/researcher.py`: main loop now `while True: step += 1`; deleted the `for…else` force-final-report block and `_DEEP_RESEARCH_MAX_STEPS`.
- `agents/explorer.py`: loop now `while True: step += 1`; deleted the trailing force-final block and `_MAX_STEPS`.

Exit contract is unchanged: developer returns the extracted Python code, researcher/explorer return the markdown report. If the LLM never emits a text response, the loop runs until SIGKILL — accepted tradeoff.

### §3 — Dead configs + consumers

| Removed key | Removed consumer |
|---|---|
| `runtime.deep_research_max_steps` | `_DEEP_RESEARCH_MAX_STEPS` (§2) |
| `runtime.explore_max_steps` | `_MAX_STEPS` (§2) |
| `runtime.baseline_time_limit` | `_BASELINE_TIME_LIMIT` in `tools/developer.py` (was defined, never read) |
| `runtime.directory_listing_max_files` | `_build_directory_listing` + `_RUN_ID_PATTERN` in `tools/helpers.py` (function was never called from anywhere) |
| `runtime.is_lower_better` | no consumer |
| `runtime.gold_threshold` | no consumer |
| `paths.external_data_dirname` | no consumer |

`tools/helpers.py`: removed the now-orphan `os` and `re` imports.

## Test plan
- [x] `pytest tests/ -q` — 59 passed. (+1 new: `test_baseline_develop_passes_goal_as_idea` — confirms baseline `develop()` with no `idea_id` receives `idea=<goal_text>`.)
- [x] `grep -Rn "goal_text\|_MAX_CODEGEN_TOOL_STEPS\|_DEEP_RESEARCH_MAX_STEPS\|_BASELINE_TIME_LIMIT\|_build_directory_listing\|is_lower_better\|gold_threshold\|external_data_dirname" agents prompts tools utils config.yaml` — only MainAgent hits on `goal_text`; everything else clean.
- [ ] End-to-end: restart the `neurogolf-2026` run. Inspect the first `DeveloperAgent.run` weave trace — `codegen_system` has no `<goal>` block and the `<idea>` block carries the session goal (baseline case). Confirm that the developer tool loop no longer terminates with the "exhausted tool steps" error.
