### PR TITLE
fix: catch SyntaxError in logging-basicconfig guard

### DIFF
--- a/guardrails/developer.py
+++ b/guardrails/developer.py
@@ -85,7 +85,19 @@ def check_logging_basicconfig_order(code: str) -> dict:
       statements, FAIL.
     Returns a dict report with status, basicConfig_line, and violations.
     """
-    module = ast.parse(code)
+    try:
+        module = ast.parse(code)
+    except SyntaxError as exc:
+        return {
+            "status": "fail",
+            "basicConfig_line": None,
+            "violations": [
+                {
+                    "line": getattr(exc, "lineno", 0) or 0,
+                    "reason": f"syntax error while parsing generated code: {exc}",
+                }
+            ],
+        }
     lines = code.splitlines()
     aliases = _collect_logger_aliases(module.body)
 


### PR DESCRIPTION
## Summary

`guardrails/developer.py:check_logging_basicconfig_order` calls `ast.parse(code)` without catching `SyntaxError`. When the developer LLM emits Python with malformed syntax (e.g. literal `\n` escapes on a single line), the exception propagates all the way up through `utils/guardrails.evaluate_guardrails` → `agents/developer.DeveloperAgent.run` → `agents/main_agent.MainAgent.run`, crashing the whole session.

## Repro

Real stacktrace from a live session (trimmed):

```
File "/workspace/Qgentic-AI/guardrails/developer.py", line 88, in check_logging_basicconfig_order
    module = ast.parse(code)
File "/venv/main/lib/python3.12/ast.py", line 52, in parse
    return compile(source, filename, mode, flags, ...)
File "<unknown>", line 305
    if b.shape[0] != out_h_expected or b.shape[1] != out_w_expected:\n                        valid = False; break
                                                                     ^
SyntaxError: unexpected character after line continuation character
```

Both `DeveloperAgent.run` and MainAgent's dispatcher expect guardrails to return a report (not raise), so this was an unhandled exception path.

## Fix

Wrap the `ast.parse` in a try/except that converts `SyntaxError` into a guardrail `status="fail"` report:

```python
try:
    module = ast.parse(code)
except SyntaxError as exc:
    return {
        "status": "fail",
        "basicConfig_line": None,
        "violations": [{"line": exc.lineno or 0, "reason": f"syntax error while parsing generated code: {exc}"}],
    }
```

Downstream already treats `status="fail"` as a guardrail block → DeveloperAgent's existing retry path fires, the LLM gets the syntax-error message in `<guardrails_block>`, and the session keeps running.

## Test plan
- [x] `pytest tests/ -q` — existing logging-guardrail tests still pass.
- [ ] Restart a live run; verify a syntax-error attempt shows up as a guardrail-block retry instead of crashing MainAgent.
