### PR TITLE
fix: handle backslash escapes in compaction summary

### DIFF
--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -80,6 +80,42 @@ def test_compact_messages_summarises_and_keeps_last_n(monkeypatch):
     assert out[1:] == msgs[4:]
 
 
+def test_compact_messages_handles_backslash_escapes_in_summary(monkeypatch):
+    """Regression: summary body containing \\d / \\w / \\n must not crash.
+
+    `re.sub` used to receive the summary body as a replacement template and
+    choke on any `\\<letter>` sequence with `re.error: bad escape`. The LLM's
+    summary can legitimately contain such sequences (regex explanations,
+    Windows paths, LaTeX). Use `.replace` instead.
+    """
+    troubling_body = r"regex: \d+\w+ and Windows path C:\Users\x; LaTeX \dfrac{a}{b}"
+    monkeypatch.setattr(
+        compact,
+        "call_llm",
+        lambda **kw: SimpleNamespace(
+            text=f"<summary>{troubling_body}</summary>"
+        ),
+    )
+    msgs = [
+        _msg("user", "u1"),
+        _msg("model", "m1"),
+        _msg("function", "f1"),
+        _msg("user", "u2"),
+        _msg("model", "m2"),
+        _msg("function", "f2"),
+        _msg("user", "u3"),
+        _msg("model", "m3"),
+    ]
+
+    out = compact_messages(msgs, model="gemini-3.1-pro-preview")
+
+    assert out[0]["role"] == "user"
+    # The raw backslash sequences survive into the summary body verbatim.
+    assert r"\d+" in out[0]["parts"][0]["text"]
+    assert r"C:\Users\x" in out[0]["parts"][0]["text"]
+    assert r"\dfrac" in out[0]["parts"][0]["text"]
+
+
 def test_compact_messages_summarises_even_when_kept_starts_on_non_user(monkeypatch):
     """MainAgent shape: only one user (index 0); kept may start on any role."""
     called = []

--- a/utils/compact.py
+++ b/utils/compact.py
@@ -159,7 +159,11 @@ def _format_summary(raw: str) -> str:
     formatted = _ANALYSIS_RE.sub("", raw)
     match = _SUMMARY_RE.search(formatted)
     if match:
-        formatted = _SUMMARY_RE.sub(
-            f"Summary:\n{match.group(1).strip()}", formatted, count=1
+        # `.replace` with a plain string avoids re.sub's replacement-template
+        # parsing — the summary body can legitimately contain literal \d, \w,
+        # etc. (regex explanations, Windows paths, LaTeX macros) which would
+        # otherwise crash `re.sub` with `re.error: bad escape`.
+        formatted = formatted.replace(
+            match.group(0), f"Summary:\n{match.group(1).strip()}", 1
         )
     return re.sub(r"\n\n+", "\n\n", formatted).strip() or raw


### PR DESCRIPTION
## Bug

Live session crashed inside `utils.compact.compact_messages` when the summariser LLM's `<summary>` body contained literal `\d`:

```
File "/workspace/Qgentic-AI/utils/compact.py", line 162, in _format_summary
    formatted = _SUMMARY_RE.sub(
File "/venv/main/lib/python3.12/re/__init__.py", line 334, in _compile_template
    return _sre.template(pattern, _parser.parse_template(repl, pattern))
re.error: bad escape \d at position 3545 (line 38, column 124)
```

This propagated up through `MainAgent.run` → `weave.op.wrapper` and tore down the entire session.

## Root cause

`_format_summary` was passing the unwrapped summary body straight to `re.sub`'s **replacement** argument. `re.sub` parses the replacement as a template — `\1`, `\g<name>`, `\\` are backreferences; everything else (`\d`, `\w`, `\n`, ...) raises `re.error: bad escape`. Summaries can legitimately contain such sequences (regex explanations, Windows paths, LaTeX macros), so anything not in the backreference whitelist would crash compaction.

## Fix

`utils/compact.py:_format_summary` now uses plain `str.replace` with `match.group(0)` as the literal needle — no template parsing at all:

```python
formatted = formatted.replace(
    match.group(0), f"Summary:\n{match.group(1).strip()}", 1
)
```

## Tests

`tests/test_compact.py::test_compact_messages_handles_backslash_escapes_in_summary` — new regression. Feeds a summary body containing `\d+\w+`, a Windows path `C:\Users\x`, and `\dfrac{a}{b}` and asserts (a) the call doesn't raise and (b) the literal sequences survive into the produced summary message.

## Test plan
- [x] `pytest tests/test_compact.py -q` — 6 passed.
- [x] `pytest tests/ -q` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)