### PR TITLE
fix #256: enforce timeout in ExecutionJob.result()

### DIFF
--- a/tests/test_developer_tools.py
+++ b/tests/test_developer_tools.py
@@ -80,6 +80,34 @@ def test_execute_code_timeout(test_script_timeout):
     assert "killed" in result.lower() or "timeout" in result.lower()
 
 
+def test_execute_code_result_honors_timeout():
+    """Regression for #256: a hung snippet must not block .result() forever.
+
+    Before the fix, ExecutionJob.result() called self._proc.wait() with no
+    timeout, so an infinite-loop snippet would pin the parent indefinitely.
+    """
+    import time
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write("import time\nwhile True:\n    time.sleep(0.05)\n")
+        script_path = f.name
+
+    try:
+        t0 = time.monotonic()
+        job = execute_code(script_path, timeout_seconds=2)
+        result = job.result()
+        elapsed = time.monotonic() - t0
+
+        assert "timeout" in result.lower(), (
+            f"expected timeout diagnostic in output, got: {result[:200]!r}"
+        )
+        assert elapsed < 5, (
+            f"result() should return within ~3s of the timeout; took {elapsed:.1f}s"
+        )
+    finally:
+        Path(script_path).unlink(missing_ok=True)
+
+
 def test_execute_code_error_returns_raw_stderr(test_script_error):
     """Test that a failing script returns raw stderr (no enrichment).
 

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -150,8 +150,18 @@ class ExecutionJob:
         Returns raw stdout on success, raw stderr on failure. Callers who want
         stack-trace enrichment can feed the stderr through
         ``web_search_stack_trace`` themselves.
+
+        Honors ``self._timeout_seconds``: if the subprocess hasn't exited by
+        then, it is killed via ``self.kill`` and the diagnostic string is
+        returned. Without this, a hung snippet would block the parent
+        indefinitely (see issue #256).
         """
-        self._proc.wait()
+        remaining = max(0.0, self._timeout_seconds - self.elapsed())
+        try:
+            self._proc.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            return self.kill(f"Hard timeout {self._timeout_seconds}s exceeded")
+
         self._stdout_thread.join(timeout=5)
         self._stderr_thread.join(timeout=5)
 


### PR DESCRIPTION
## Bug — issue #256

`ExecutionJob.result()` called `self._proc.wait()` with no `timeout` argument, so a hung snippet (infinite loop, blocked I/O, etc.) would pin the parent's `analyze` call indefinitely. The `timeout_seconds` value passed into `execute_code` was stashed on the job but only consulted by `job.check_timeout()` — and `check_timeout()` is only polled inside `execute_with_monitor`, which the `analyze` paths in `agents/developer.py:_execute_developer_tool_call` and `agents/main_agent.py:_dispatch` don't use.

Live impact: a snippet started at 02:01:09 with a declared `timeout=300s` was still running 15 minutes later, blocking the parent's LLM loop. The "timeout=300" log line was purely informational; nothing enforced it.

## Fix

`tools/developer.py:ExecutionJob.result()` now respects its own `_timeout_seconds`:

```python
remaining = max(0.0, self._timeout_seconds - self.elapsed())
try:
    self._proc.wait(timeout=remaining)
except subprocess.TimeoutExpired:
    return self.kill(f"Hard timeout {self._timeout_seconds}s exceeded")
```

`kill()` already exists, kills the process group, joins the reader threads, and returns a diagnostic string — same return-type contract as the success path, so callers don't need to change.

## Tests

`tests/test_developer_tools.py::test_execute_code_result_honors_timeout` — new regression. Writes a `while True: time.sleep(0.05)` snippet, calls `execute_code(..., timeout_seconds=2).result()`, asserts the call returns within ~5s and the result string contains "timeout".

## Test plan
- [x] `pytest tests/test_developer_tools.py -q` — green.
- [x] `pytest tests/ -q` — full suite green.
- [ ] Live smoke: launch a session, watch a deliberately-hung `analyze` snippet get killed at the configured timeout instead of pinning the parent.

Closes #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)