### PR TITLE
fix #257: nudge MainAgent when it spins on identical tool calls

### DIFF
--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -13,6 +13,7 @@ after every idea-pool mutation).
 
 from __future__ import annotations
 
+import collections
 import json
 import logging
 import threading
@@ -39,6 +40,23 @@ _INITIAL_USER_TURN = (
     "Take your first step. The session goal, the current idea pool (INDEX.md), "
     "and your tool palette are all in the system prompt. Pick a tool and call "
     "it — every step should be a tool call, never a plain text response."
+)
+
+# Number of consecutive turns with byte-identical tool-call signatures before
+# the stuck-detection nudge fires. Set to 3 so a "double-check then act" pattern
+# doesn't false-positive, but a degenerate spin (e.g. repeated `analyze(time.sleep)`)
+# is caught before it burns much budget.
+_STUCK_REPEAT_THRESHOLD = 3
+
+_STUCK_NUDGE = (
+    "You've made the same tool call(s) for the last "
+    f"{_STUCK_REPEAT_THRESHOLD} turns. That's a sign you're out of ideas, not "
+    "that the work is done. **Push on.** Concrete options: add a fresh idea "
+    "via `add_idea`; call `research(instruction=\"...\")` to web-search for "
+    "unblocking ideas; inspect a `developer_N/` directory you haven't reviewed "
+    "yet; reread INDEX.md and pick the next-most-promising idea. **Never "
+    "stop** — the session has no termination condition. The user will SIGKILL "
+    "when satisfied."
 )
 
 
@@ -79,6 +97,12 @@ class MainAgent:
         # this list.
         self.input_list: list[dict] = [append_message("user", _INITIAL_USER_TURN)]
         self.last_input_tokens: int | None = None
+        # Rolling window of per-turn tool-call signatures. When the deque is
+        # full and every entry is identical, the agent is spinning on a no-op
+        # — `_step` injects `_STUCK_NUDGE` to push it back to productive work.
+        self._recent_call_sigs: collections.deque[tuple[tuple[str, str], ...]] = (
+            collections.deque(maxlen=_STUCK_REPEAT_THRESHOLD)
+        )
         # Ensure INDEX.md exists so `load_index` has something to read.
         if not (self.ideas_dir / "INDEX.md").exists():
             (self.ideas_dir / "INDEX.md").write_text("# Idea pool\n\n")
@@ -174,6 +198,29 @@ class MainAgent:
                 mode="json", exclude_none=True
             )
         )
+
+        # Stuck detection: if the last N turns made byte-identical tool calls,
+        # the agent is spinning on a no-op (e.g. repeated `analyze(time.sleep(2))`
+        # after it thinks the goal is met). Inject a static "push on / never stop"
+        # nudge so it tries something new instead.
+        turn_sig = tuple(
+            (name, json.dumps(args, sort_keys=True, ensure_ascii=False))
+            for name, args, _ in results
+        )
+        self._recent_call_sigs.append(turn_sig)
+        if (
+            len(self._recent_call_sigs) == _STUCK_REPEAT_THRESHOLD
+            and len(set(self._recent_call_sigs)) == 1
+        ):
+            logger.warning(
+                "MainAgent appears stuck: same %d-call turn repeated %d times "
+                "(%s) — injecting unstucking nudge",
+                len(turn_sig),
+                _STUCK_REPEAT_THRESHOLD,
+                [n for n, _ in turn_sig],
+            )
+            self.input_list.append(append_message("user", _STUCK_NUDGE))
+            self._recent_call_sigs.clear()
 
     def _dispatch(self, name: str, args: dict) -> str:
         if name == "develop":

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -236,6 +236,72 @@ def test_parallel_analyze_calls_get_distinct_snippet_numbers(
     assert any("print('c')" in c for c in contents)
 
 
+def test_stuck_nudge_fires_after_repeated_identical_calls(
+    patched_main_agent, monkeypatch
+):
+    """If the same single-call turn repeats N times, MainAgent appends a static
+    "push on / never stop" nudge to input_list and clears its history.
+
+    Regression for #257 — the live failure showed `analyze(time.sleep(2))` repeated
+    623 times in a row.
+    """
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+
+    response = _fake_fc("analyze", code="import time\ntime.sleep(2)\nprint('Waiting...')")
+    monkeypatch.setattr(main_agent, "call_llm", lambda **kwargs: (response, 0))
+
+    threshold = main_agent._STUCK_REPEAT_THRESHOLD
+    nudge_text = main_agent._STUCK_NUDGE
+
+    def _has_nudge(messages: list[dict]) -> bool:
+        for msg in messages:
+            if msg.get("role") != "user":
+                continue
+            for part in msg.get("parts", []):
+                if nudge_text in part.get("text", ""):
+                    return True
+        return False
+
+    # First (threshold-1) repeats: no nudge yet — pattern not confirmed.
+    for _ in range(threshold - 1):
+        agent._step([])
+    assert not _has_nudge(agent.input_list)
+
+    # The threshold'th identical turn triggers the nudge.
+    agent._step([])
+    last = agent.input_list[-1]
+    assert last["role"] == "user"
+    assert nudge_text in last["parts"][0]["text"]
+
+    # History reset, so the next identical turn does NOT immediately re-nudge.
+    agent._step([])
+    assert agent.input_list[-1]["role"] == "function"
+
+
+def test_stuck_nudge_does_not_fire_for_varied_calls(patched_main_agent, monkeypatch):
+    """A turn whose tool args differ from the previous resets the stuck window."""
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+
+    threshold = main_agent._STUCK_REPEAT_THRESHOLD
+    nudge_text = main_agent._STUCK_NUDGE
+
+    responses = iter(
+        [_fake_fc("analyze", code=f"print({i})") for i in range(threshold + 2)]
+    )
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (next(responses), 0)
+    )
+
+    for _ in range(threshold + 2):
+        agent._step([])
+
+    for msg in agent.input_list:
+        if msg.get("role") != "user":
+            continue
+        for part in msg.get("parts", []):
+            assert nudge_text not in part.get("text", "")
+
+
 def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatch, caplog):
     agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
     monkeypatch.setattr(


### PR DESCRIPTION
## Bug — issue #257

After MainAgent finished its useful work in run `20260423_002853` (lifted score by +15.40 to 4316.80, packaged `submission.zip`, logged a "Victory and Summary" idea), it had **nothing else productive to do**.

The system prompt forbids text-only responses (*"every step should be a tool call"*) and declares no termination condition (*"the user stops the process when satisfied"*). With no real work left, the LLM picked the cheapest no-op available — `analyze` running `import time; time.sleep(2); print("Waiting...")` — and repeated it **623 times in a row** with byte-identical args, plus 34/61/27 attempts at three earlier sleep variants. 7+ hours of spinning before the user SIGKILLed.

```
$ md5sum task/neurogolf-2026/20260423_002853/main_agent_snippets/*.py | sort | uniq -c -w 32 | sort -rn | head -4
    623 04f95a26…   # time.sleep(2); print("Waiting...")     ← snippets 210→834
     61 fe80b1ca…   # time.sleep(1); print("Waiting for SIGKILL...")
     34 0c3661d5…   # time.sleep(2); print(".")
     27 1aa145bd…   # time.sleep(1); print("Waiting...")
```

(See https://github.com/bogoconic1/Qgentic-AI/issues/257 for the full repro analysis.)

## Fix — never stop, just nudge harder

Per discussion: the agent should not have an exit affordance. When it starts spinning, the right intervention is a static nudge that tells it the spin itself is the signal it's out of ideas, and points at concrete unstucking actions.

`agents/main_agent.py`:

- New rolling window `self._recent_call_sigs: deque(maxlen=3)` records the per-turn tool-call signature `(name, sorted-args-json)`.
- After each `_step` dispatch, if the deque is full and every entry is byte-identical, append a static `_STUCK_NUDGE` user message to `input_list` and `clear()` the deque. The nudge tells the agent it's spinning, lists concrete options (`add_idea` / `research(instruction=...)` / inspect a `developer_N/` dir / re-read INDEX.md), and reaffirms "never stop".
- Clearing the deque after the nudge fires means **one nudge per stuck episode**, then the next 3 turns can rebuild the pattern from scratch — avoids spamming `input_list` with 600+ identical paragraphs while still re-firing if the LLM ignores it.

## Tests

`tests/test_main_agent.py`:

- `test_stuck_nudge_fires_after_repeated_identical_calls` — feeds the live-failure repro (`analyze(time.sleep(2); print("Waiting..."))`) `_STUCK_REPEAT_THRESHOLD` times, asserts the nudge appears in `input_list[-1]`, and asserts the next identical turn does NOT immediately re-nudge (history was cleared).
- `test_stuck_nudge_does_not_fire_for_varied_calls` — feeds different `code` args each turn, asserts no nudge.

## Test plan
- [x] `pytest tests/test_main_agent.py -q` — green (7 passed, was 5).
- [x] `pytest tests/ -q` — full suite green.
- [ ] Live smoke: re-run the agent past the "Victory and Summary" point; expect the nudge in `main_agent_chat.jsonl` instead of byte-identical `time.sleep(2)` repetitions filling `main_agent_snippets/`.

Closes #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)