### PR TITLE
wire filesystem tools into MainAgent (#264)

### DIFF
--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -29,6 +29,7 @@ from agents.researcher import ResearcherAgent
 from project_config import get_config
 from prompts.main_agent import build_system
 from tools.developer import _build_resource_header, execute_code
+from tools.filesystem import execute_filesystem_tool
 from tools.helpers import call_llm
 from utils.compact import compact_messages, should_compact
 from utils.idea_pool import add_idea, load_index, remove_idea, update_idea
@@ -277,6 +278,10 @@ class MainAgent:
             with self._idea_lock:
                 update_idea(self.ideas_dir, args["idea_id"], args["description"])
             return json.dumps({"ok": True})
+
+        fs_result = execute_filesystem_tool(name, args)
+        if fs_result is not None:
+            return truncate_for_llm(fs_result)
 
         return json.dumps({"error": f"Unknown tool: {name}"})
 

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -36,6 +36,11 @@ Be bold — a turn with 3-4 parallel calls is a normal, encouraged pattern. Hesi
 - `add_idea(title: str, description: str)` — add an entry to the pool; returns the assigned integer id. INDEX.md above regenerates automatically.
 - `remove_idea(idea_id: int)` — remove a dead idea.
 - `update_idea(idea_id: int, description: str)` — revise an existing idea's body. Title stays.
+- `read_file(path, start_line?, end_line?)` — read a file with line numbers. Use this for quick file inspection (a `train.py` from a prior `developer_N/` run, a `valid_preds.csv` header, an idea body) instead of spinning up `analyze` to `print(open(...).read())`.
+- `glob_files(root, pattern)` — list files matching a glob under `root` (e.g. find every `train_stats.json` under `task/<slug>/<run_id>/`).
+- `grep_code(root, pattern, file_glob?, max_results?)` — recursive regex search; cheap way to grep for a function name or leakage pattern across the run directory.
+- `list_dir(path, max_entries?)` — directory listing with `/` suffix on subdirectories.
+- `bash(command)` — run a shell command via `bash -c` (pipes, redirection, chaining all work). Every command is judged by an LLM safety judge first; destructive operations (`rm -rf /`, `dd`, `mkfs`, fork bombs, pipe-to-shell, writes to system paths, force-pushes, shutdown) are blocked. Use it for the long tail of operations the dedicated tools don't cover — `cp`, `mv`, `mkdir`, project-scoped `rm`, `tar`, `pip install`, `python script.py | tee log`. Strongly preferred over wrapping `os.system(...)` inside an `analyze` snippet.
 
 # CRITICAL: do not do the developer's job yourself
 

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -302,6 +302,35 @@ def test_stuck_nudge_does_not_fire_for_varied_calls(patched_main_agent, monkeypa
             assert nudge_text not in part.get("text", "")
 
 
+def test_filesystem_tool_calls_route_to_filesystem_helpers(
+    patched_main_agent, monkeypatch
+):
+    """A `list_dir` tool call from MainAgent is dispatched to tools.filesystem."""
+    captured = {}
+
+    def fake_execute_filesystem_tool(name, args):
+        captured["name"] = name
+        captured["args"] = args
+        return json.dumps({"entries": ["fake/"], "total": 1})
+
+    monkeypatch.setattr(
+        main_agent, "execute_filesystem_tool", fake_execute_filesystem_tool
+    )
+
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+    response = _fake_fc("list_dir", path="/workspace")
+    monkeypatch.setattr(main_agent, "call_llm", lambda **kwargs: (response, 0))
+
+    agent._step([])
+
+    assert captured == {"name": "list_dir", "args": {"path": "/workspace"}}
+    records = [json.loads(line) for line in agent.chat_log.read_text().splitlines()]
+    tool_records = [r for r in records if r["role"] == "tool"]
+    assert len(tool_records) == 1
+    assert tool_records[0]["name"] == "list_dir"
+    assert json.loads(tool_records[0]["result"])["entries"] == ["fake/"]
+
+
 def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatch, caplog):
     agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
     monkeypatch.setattr(

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -478,6 +478,7 @@ def get_main_agent_tools():
                 "required": ["idea_id", "description"],
             },
         ),
+        *get_filesystem_tools(),
     ]
 
 


### PR DESCRIPTION
Stacked on top of #265.

Extends the filesystem tool palette (`read_file`, `glob_files`, `grep_code`, `list_dir`, `bash`) — already available to the developer and researcher subagents in #265 — to MainAgent.

## Why

Today MainAgent has to wrap every directory listing, file read, or shell op in an `analyze` snippet that prints the result. That's verbose, slow (subprocess spawn per call), and burns context (the whole snippet body shows up in the chat log). With direct filesystem tools, MainAgent can:

- `read_file("task/<slug>/<run_id>/developer_3/1/train.py", start_line=1, end_line=80)` instead of `analyze("print(open('....').read()[:5000])")`.
- `grep_code(root, "valid_score", file_glob="*.py")` to find every place a particular metric is computed across the run dir.
- `bash("ls task/<slug>/<run_id>/developer_*/1/train_stats.json | xargs -I{} jq .score {}")` for cross-iteration score sweeps.

The intended pattern is "use the dedicated tool when it fits, fall back to `analyze` only when you need real Python."

## What changed

- `utils/llm_utils.py:get_main_agent_tools()` splats in `get_filesystem_tools()` (same five FunctionDeclarations the developer/researcher already get).
- `agents/main_agent.py:_dispatch` falls through to `tools.filesystem.execute_filesystem_tool` after the existing `develop` / `research` / `analyze` / idea-pool branches. Result is run through `truncate_for_llm` like every other dispatcher already does.
- `prompts/main_agent.py` describes the five new tools in the tool-palette section, including the bash judge's allow/block policy.
- `tests/test_main_agent.py` adds `test_filesystem_tool_calls_route_to_filesystem_helpers` — monkeypatches `execute_filesystem_tool`, sends a `list_dir` call through `_step`, and asserts the dispatcher routed it correctly and the chat log captured the result.

## Notes

- The `bash` judge cache is global (lru_cache), so when MainAgent and a developer subagent both ask "is `mkdir -p task/X` safe?" the second call is free.
- No config changes — `bash_judge_model` and `bash_timeout_seconds` were both added in #265 and apply here too.
- Stuck-detection (#262) treats every tool name uniformly, so a degenerate spin on `list_dir` with the same path will still trigger the nudge.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_helpers.py --ignore=tests/test_developer_tools.py` — 41 passed locally
- [ ] Manual smoke: launch a session, watch MainAgent use `read_file` / `bash` directly instead of wrapping in `analyze`