### PR TITLE
fix #254: read DEVELOPER_INSTRUCTIONS.md / RESEARCHER_INSTRUCTIONS.md per task

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -143,6 +143,13 @@ class DeveloperAgent:
                     return train_py.read_text()
         return None
 
+    def _load_custom_instructions(self) -> str | None:
+        """Read `task/<slug>/DEVELOPER_INSTRUCTIONS.md` if it exists."""
+        path = _TASK_ROOT / self.slug / "DEVELOPER_INSTRUCTIONS.md"
+        if not path.exists():
+            return None
+        return path.read_text(encoding="utf-8")
+
     @weave.op()
     def run(self, idea: str) -> dict[str, Any]:
         """Run one developer iteration; retry on failure until success."""
@@ -150,6 +157,7 @@ class DeveloperAgent:
         system_prompt = codegen_system(
             idea=idea,
             previous_code=previous_code,
+            custom_instructions=self._load_custom_instructions(),
         )
 
         input_list: list[dict] = [

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -233,6 +233,13 @@ class ResearcherAgent:
         self.web_research_dir = self.research_dir / "web_research"
         self.web_fetch_dir = self.research_dir / "web_fetch"
 
+    def _load_custom_instructions(self) -> str | None:
+        """Read `task/<slug>/RESEARCHER_INSTRUCTIONS.md` if it exists."""
+        path = _TASK_ROOT / self.slug / "RESEARCHER_INSTRUCTIONS.md"
+        if not path.exists():
+            return None
+        return path.read_text(encoding="utf-8")
+
     @weave.op()
     def run(self, instruction: str) -> str:
         """Run the Deep Research loop and return a markdown report.
@@ -259,7 +266,9 @@ class ResearcherAgent:
             instruction,
         )
 
-        system_prompt = build_system()
+        system_prompt = build_system(
+            custom_instructions=self._load_custom_instructions(),
+        )
         user_prompt = build_user(instruction)
         tools = get_deep_research_tools()
         state: dict = {

--- a/prompts/developer.py
+++ b/prompts/developer.py
@@ -15,6 +15,7 @@ from pathlib import Path
 def codegen_system(
     idea: str,
     previous_code: str | None = None,
+    custom_instructions: str | None = None,
 ) -> str:
     idea_section = f"\n<idea>\n{idea}\n</idea>\n"
 
@@ -30,8 +31,16 @@ def codegen_system(
             "</previous_code>\n"
         )
 
+    custom_section = ""
+    if custom_instructions and custom_instructions.strip():
+        custom_section = (
+            "\n<custom_instructions>\n"
+            f"{custom_instructions.strip()}\n"
+            "</custom_instructions>\n"
+        )
+
     return f"""You are a developer producing a single Python script (`train.py`) that implements the task specified by the `<idea>` block below. Output one complete script per attempt; the previous attempt's code and any failure feedback are visible above in the conversation thread.
-{idea_section}{previous_section}
+{idea_section}{previous_section}{custom_section}
 ## Hard constraints
 
 - Place `import logging` and `logging.basicConfig(level=logging.INFO, ...)` at the very top of the script, BEFORE any third-party imports (torch, transformers, numpy, etc.). Third-party libraries configure logging on import, so basicConfig must come first. A pre-execution guardrail enforces this and will block the script otherwise.

--- a/prompts/research.py
+++ b/prompts/research.py
@@ -10,8 +10,17 @@ originate from a prior tool result (no model-authored URLs).
 from __future__ import annotations
 
 
-def build_system() -> str:
-    return """You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
+def build_system(custom_instructions: str | None = None) -> str:
+    custom_section = ""
+    if custom_instructions and custom_instructions.strip():
+        custom_section = (
+            "\n<custom_instructions>\n"
+            f"{custom_instructions.strip()}\n"
+            "</custom_instructions>\n\n"
+        )
+
+    return f"""You are Deep Research: a specialist sub-agent that discovers and reads web content to answer a research query from the agent that called you, and emits a structured markdown report.
+{custom_section}
 
 === CRITICAL: READ-ONLY MODE ===
 You may not modify, create, or delete files outside of `write_python_code`'s scratch directory. You have no Edit/Write tools — attempting any is a bug.

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -216,6 +216,29 @@ def test_filesystem_tool_calls_route_to_filesystem_helpers(
     assert json.loads(result)["entries"] == ["fake/"]
 
 
+def test_developer_instructions_appended_to_system_prompt(fake_pipeline, tmp_path):
+    """If task/<slug>/DEVELOPER_INSTRUCTIONS.md exists, its body is inlined."""
+    task_dir = tmp_path / "task" / "test-slug"
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "DEVELOPER_INSTRUCTIONS.md").write_text(
+        "Always emit the score as a percent multiplied by 100."
+    )
+
+    dev = DeveloperAgent(slug="test-slug", run_id="r1", dev_iter=1)
+    dev.run(idea="Produce a finite score.")
+
+    system_prompt = fake_pipeline["system_prompts"][0]
+    assert "<custom_instructions>" in system_prompt
+    assert "Always emit the score as a percent multiplied by 100." in system_prompt
+
+
+def test_developer_instructions_omitted_when_file_missing(fake_pipeline, tmp_path):
+    """Absent DEVELOPER_INSTRUCTIONS.md → no <custom_instructions> section."""
+    dev = DeveloperAgent(slug="test-slug", run_id="r1", dev_iter=1)
+    dev.run(idea="Produce a finite score.")
+    assert "<custom_instructions>" not in fake_pipeline["system_prompts"][0]
+
+
 def test_previous_code_threaded_into_system_prompt(fake_pipeline, tmp_path):
     """dev_iter=2 with a prior successful developer_1/<k>/ should inline previous_code."""
     # Seed a prior successful run

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -182,6 +182,25 @@ def test_filesystem_tool_calls_route_to_filesystem_helpers(stubbed, monkeypatch)
     assert json.loads(out)["returncode"] == 0
 
 
+def test_build_system_inlines_custom_instructions():
+    """The researcher system prompt inlines RESEARCHER_INSTRUCTIONS.md when present."""
+    from prompts.research import build_system
+
+    body = "Cite at least three peer-reviewed sources per claim."
+    out = build_system(custom_instructions=body)
+    assert "<custom_instructions>" in out
+    assert body in out
+
+
+def test_build_system_omits_section_when_no_instructions():
+    """Absent / empty custom_instructions → no <custom_instructions> wrapper."""
+    from prompts.research import build_system
+
+    assert "<custom_instructions>" not in build_system()
+    assert "<custom_instructions>" not in build_system(custom_instructions="")
+    assert "<custom_instructions>" not in build_system(custom_instructions="   \n")
+
+
 def test_render_tool_record_markdown_error_path():
     rendered = research_module._render_tool_record_markdown(
         "web_research", 2, {"query": "q"}, json.dumps({"error": "exa down"})


### PR DESCRIPTION
Closes #254.

Stacked on top of #266.

Lets each task customise its developer / researcher subagents by dropping a markdown file in the task directory — no code change, no agent restart.

## Why

Per-task overrides used to live in user-side hardcoded strings. That meant changing instructions for one Kaggle slug required editing the framework itself, and there was no separation between *generic* developer/researcher behaviour and *this-particular-competition* nuances (preferred metrics, leakage rules, "always include arc-gen", domain-specific gotchas).

The fix mirrors the existing `task/<slug>/GOAL.md` convention: any task can drop optional markdown files alongside the goal and they get inlined into the system prompt at run time.

## What changed

- `agents/developer.py:_load_custom_instructions()` reads `task/<slug>/DEVELOPER_INSTRUCTIONS.md` if it exists and threads the body into `codegen_system(custom_instructions=...)`.
- `agents/researcher.py:_load_custom_instructions()` reads `task/<slug>/RESEARCHER_INSTRUCTIONS.md` if it exists and threads the body into `build_system(custom_instructions=...)`.
- `prompts/developer.py:codegen_system` and `prompts/research.py:build_system` accept an optional `custom_instructions: str | None`; when present and non-empty after `strip()`, it's inlined as a `<custom_instructions>{body}</custom_instructions>` XML-style block. Absent / empty / whitespace-only → no block at all (no stray header).
- Both files are optional — missing file or empty content is a no-op, so existing tasks keep working unchanged.

## Tests

- `tests/test_developer.py`: `test_developer_instructions_appended_to_system_prompt` writes a `DEVELOPER_INSTRUCTIONS.md` and asserts both the wrapper and the body land in the codegen system prompt; `test_developer_instructions_omitted_when_file_missing` asserts no wrapper appears when the file isn't there.
- `tests/test_researcher.py`: `test_build_system_inlines_custom_instructions` and `test_build_system_omits_section_when_no_instructions` cover the prompt builder directly, including the whitespace-only edge case.

## Test plan

- [x] \`pytest tests/ --ignore=tests/test_helpers.py --ignore=tests/test_developer_tools.py\` — green locally
- [ ] Manual smoke: drop \`task/<slug>/DEVELOPER_INSTRUCTIONS.md\`, run a developer iteration, confirm the body shows up in the audit log of the codegen system prompt