### PR TITLE
wire write_file and edit_file into get_filesystem_tools()

### DIFF
--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -257,3 +257,37 @@ def test_execute_filesystem_tool_routes_by_name(sandbox, monkeypatch):
     assert json.loads(out)["returncode"] == 0
 
     assert fs.execute_filesystem_tool("nope", {}) is None
+
+
+# ---------------------------------------------------------------------------
+# LLM-side palette: get_filesystem_tools() must stay in sync with the dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_get_filesystem_tools_palette_matches_dispatcher():
+    """The FunctionDeclaration palette and the dispatcher's tool-name set must
+    list the same tools. If they drift, agents will either advertise tools the
+    dispatcher cannot run, or the dispatcher will silently support tools the
+    LLM is never told about."""
+    from utils.llm_utils import get_filesystem_tools
+
+    palette_names = {t.name for t in get_filesystem_tools()}
+    assert palette_names == fs.FILESYSTEM_TOOL_NAMES
+
+
+def test_get_filesystem_tools_write_and_edit_schemas():
+    """write_file and edit_file declarations carry the parameter schema we need
+    for the dispatcher to call into the helpers correctly."""
+    from utils.llm_utils import get_filesystem_tools
+
+    by_name = {t.name: t for t in get_filesystem_tools()}
+
+    write = by_name["write_file"].parameters_json_schema
+    assert set(write["required"]) == {"path", "content"}
+    assert write["properties"]["path"]["type"] == "string"
+    assert write["properties"]["content"]["type"] == "string"
+
+    edit = by_name["edit_file"].parameters_json_schema
+    assert set(edit["required"]) == {"path", "old_string", "new_string"}
+    assert edit["properties"]["replace_all"]["type"] == "boolean"
+    assert "replace_all" not in edit["required"]

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -301,6 +301,66 @@ def get_filesystem_tools():
                 "required": ["command"],
             },
         ),
+        types.FunctionDeclaration(
+            name="write_file",
+            description=(
+                "Write a file to the local filesystem. Creates parent "
+                "directories as needed and overwrites any existing file at "
+                "`path`. Prefer `edit_file` for in-place modifications since "
+                "it only sends the diff; use `write_file` for new files or "
+                "full rewrites. Path must resolve under one of the configured "
+                "allowed roots."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Absolute path or path relative to cwd.",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Full file content to write.",
+                    },
+                },
+                "required": ["path", "content"],
+            },
+        ),
+        types.FunctionDeclaration(
+            name="edit_file",
+            description=(
+                "Perform an exact-string replacement inside a file. "
+                "`old_string` must match a unique substring; if the file "
+                "contains more than one occurrence, set `replace_all` to "
+                "true. Curly quotes are normalized so a straight-quote "
+                "`old_string` matches typographic content. To create a new "
+                "file pass an empty `old_string` and the desired content as "
+                "`new_string`. Path must resolve under one of the configured "
+                "allowed roots."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Absolute path or path relative to cwd.",
+                    },
+                    "old_string": {
+                        "type": "string",
+                        "description": "Substring to replace; must be unique unless replace_all is true. Empty string + missing file = create.",
+                    },
+                    "new_string": {
+                        "type": "string",
+                        "description": "Replacement text. Empty string deletes old_string.",
+                    },
+                    "replace_all": {
+                        "type": "boolean",
+                        "description": "Replace every occurrence of old_string instead of failing on multiple matches (default: false).",
+                    },
+                },
+                "required": ["path", "old_string", "new_string"],
+            },
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary

Stacked on #273. Wires `write_file` and `edit_file` into the LLM-callable filesystem palette by adding two `FunctionDeclaration`s to `utils/llm_utils.py:get_filesystem_tools()`. Every consumer palette (`get_main_agent_tools`, `get_deep_research_tools`) already splats `*get_filesystem_tools()`, so MainAgent and ResearcherAgent gain access to the new tools immediately — no agent-side or prompt changes needed.

After this PR closes the loop opened by #272: the Python helpers existed, the dispatcher routed them, but no LLM was told the tool names. Now they are.

## What's added

- `utils/llm_utils.py:get_filesystem_tools()` — two new `FunctionDeclaration` entries:
  - `write_file(path, content)` — full-file write; description redirects to `edit_file` for in-place changes.
  - `edit_file(path, old_string, new_string, replace_all=false)` — exact-string replacement with the multi-match guard and curly-quote normalization documented; empty `old_string` + missing file = create.
- This PR establishes the boolean-with-default convention for this codebase (`replace_all`); prior `parameters_json_schema` entries had no boolean params.

## What's NOT in this PR

- DeveloperAgent rewrite (separate PR; blocked on the train.py-execution design call).
- `bash` description tweak (current text already says "use this for the long tail of operations the dedicated tools don't cover").
- Any prompt updates.

## Verification

- `pytest tests/ --ignore=tests/test_helpers.py` — 58 passed (56 existing + 2 new).
- `python -c "from utils.llm_utils import get_filesystem_tools; print(sorted(t.name for t in get_filesystem_tools()))"` returns `['bash', 'edit_file', 'glob_files', 'grep_code', 'list_dir', 'read_file', 'write_file']`.
- Two new sanity tests guard against drift between palette and dispatcher:
  - `test_get_filesystem_tools_palette_matches_dispatcher` — palette name set must equal `FILESYSTEM_TOOL_NAMES`.
  - `test_get_filesystem_tools_write_and_edit_schemas` — required-field sets and `replace_all` boolean type are correct.

## Test plan

- [x] Unit tests pass
- [x] Palette and dispatcher are in sync
- [ ] Live smoke-test once a consuming agent is exercised against a real Gemini call (out of band)