### PR TITLE
make RESEARCH.md the canonical Researcher artifact

### DIFF
--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -20,7 +20,10 @@ Per-invocation layout (owned by this module):
     │   └── <seq>.md
     ├── web_fetch/     # per-call audit records for web_fetch
     │   └── <seq>.md
-    └── PLAN_<research_iter>.md   # final markdown report
+    └── RESEARCH.md    # the final report — scaffolded at run start with a
+                       # single H1 ("# {instruction}"), populated by the
+                       # agent via write_file/edit_file, and read back at
+                       # termination as the run's return value.
 """
 
 from __future__ import annotations
@@ -205,6 +208,7 @@ class ResearcherAgent:
         self.research_dir = _TASK_ROOT / slug / run_id / f"research_{research_iter}"
         self.web_research_dir = self.research_dir / "web_research"
         self.web_fetch_dir = self.research_dir / "web_fetch"
+        self.research_md_path = self.research_dir / "RESEARCH.md"
 
     def _load_custom_instructions(self) -> str | None:
         """Read `task/<slug>/RESEARCHER_INSTRUCTIONS.md` if it exists."""
@@ -217,18 +221,27 @@ class ResearcherAgent:
     def run(self, instruction: str) -> str:
         """Run the Deep Research loop and return a markdown report.
 
-        Creates ``task/<slug>/<run_id>/research_<research_iter>/``, runs the
-        tool loop, and persists the final markdown as ``PLAN_<research_iter>.md``
-        inside that directory. The markdown is also returned.
+        Creates ``task/<slug>/<run_id>/research_<research_iter>/``, scaffolds
+        ``RESEARCH.md`` with a single H1 (``# {instruction}``) so the agent
+        has a known target to ``write_file``/``edit_file`` into, runs the
+        tool loop, and reads ``RESEARCH.md`` back at termination — that file
+        IS the report.
 
         Args:
             instruction: Free-form research instruction — as long as needed.
 
         Returns:
-            Free-form markdown report with URL citations.
+            Contents of ``RESEARCH.md`` after the run.
         """
         for d in (self.web_research_dir, self.web_fetch_dir):
             d.mkdir(parents=True, exist_ok=True)
+
+        self.research_md_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.research_md_path.exists():
+            self.research_md_path.write_text(
+                f"# {instruction}\n",
+                encoding="utf-8",
+            )
 
         logger.info(
             "ResearcherAgent.run slug=%s run_id=%s iter=%d dir=%s instruction=%r",
@@ -251,7 +264,6 @@ class ResearcherAgent:
         input_list: list[dict] = [append_message("user", user_prompt)]
         last_input_tokens: int | None = None
 
-        markdown = ""
         step = 0
         while True:
             step += 1
@@ -280,7 +292,6 @@ class ResearcherAgent:
 
             if not has_function_calls:
                 logger.info("ResearcherAgent completed at step %d", step)
-                markdown = response.text or ""
                 break
 
             function_responses = []
@@ -306,8 +317,10 @@ class ResearcherAgent:
                     ).model_dump(mode="json", exclude_none=True)
                 )
 
-        plan_path = self.research_dir / f"PLAN_{self.research_iter}.md"
-        plan_path.write_text(markdown)
-        logger.info("ResearcherAgent wrote %s (%d chars)", plan_path, len(markdown))
-
-        return markdown
+        report = self.research_md_path.read_text(encoding="utf-8")
+        logger.info(
+            "ResearcherAgent read %s (%d chars)",
+            self.research_md_path,
+            len(report),
+        )
+        return report

--- a/prompts/research.py
+++ b/prompts/research.py
@@ -25,12 +25,13 @@ def build_system(custom_instructions: str | None = None) -> str:
 {custom_section}
 
 === Scope ===
-You have no Edit/Write tools. Use `bash` (`python -c "..."`, `python /tmp/script.py`, etc.) for any scripted execution; `read_file` / `glob_files` / `grep_code` / `list_dir` for inspection.
+Use `bash` (`python -c "..."`, `python /tmp/script.py`, etc.) for any scripted execution; `read_file` / `glob_files` / `grep_code` / `list_dir` for inspection; `write_file` / `edit_file` to maintain `RESEARCH.md`.
 
 ## Available tools
-- `web_research(query, num_results?)` — discover web pages for a query via Exa neural search. Returns up to `num_results` records, each with `url`, `title`, `text` (full page text, not a snippet), and `published_date`. Default 10, max 20. This is your ONLY URL-discovery path.
+- `web_research(query, num_results?)` — discover web pages for a query via Exa neural search. Returns up to `num_results` records, each with `url`, `title`, `text` (full page text, not a snippet), and `published_date`. This is your ONLY URL-discovery path.
 - `web_fetch(url)` — fetch a single URL's main content as markdown via Firecrawl. Full content is returned; there is no truncation.
 - `read_file(path, start_line?, end_line?)` / `glob_files` / `grep_code` / `list_dir` — read-only filesystem inspection.
+- `write_file(path, content)` / `edit_file(path, old_string, new_string, replace_all?)` — maintain `RESEARCH.md` as you accumulate findings (see "RESEARCH.md is your deliverable" below).
 - `bash(command)` — run a shell command via `bash -c`. Use for scripted execution (`python -c "..."`, `python /tmp/probe.py`), API probing, quick computations, dataset sniffing — anything you'd run in a notebook to validate an idea. Destructive operations are blocked by an LLM safety judge.
 
 ## URL provenance rule (critical)
@@ -41,23 +42,25 @@ You may only call `web_fetch(url)` with a URL that appeared in:
 Do NOT invent URLs. Do NOT reconstruct URLs from prose. Do NOT modify query strings or path segments on URLs from results. If you need a URL you do not have, run `web_research` first.
 
 ## How to work
-- Start with `web_research` to map the landscape, then pick 2-5 URLs worth deep-reading.
+- Start with `web_research` to map the landscape, then pick the URLs worth deep-reading.
 - `web_fetch` is expensive — skip pages whose search snippet/text already answers the question.
 - Follow inline markdown links inside a fetched page only when they clearly advance the query.
-- Prefer 3 deep fetches over 10 shallow ones.
 - Spawn parallel tool calls when they don't depend on each other.
 
-## Output contract
-When you have enough material, stop calling tools and emit your **final markdown report** as a regular message. The parent agent will save this markdown verbatim as a `PLAN.md`-style artifact, so it must be self-contained.
+## RESEARCH.md is your deliverable
+A scaffolded `RESEARCH.md` already exists at the root of your research directory. **You must populate it.** Use `write_file` for the initial structure or full rewrites, `edit_file` to slot in sections / citations / notes as you accumulate findings. Maintain it as a living document throughout the run, not as a one-shot dump at the end.
 
-Every concrete claim must cite a URL — either inline as `(https://...)` after the claim, or as a footnote-style `[^n]` with URLs listed at the bottom. No naked assertions.
+Every concrete claim in `RESEARCH.md` must cite a URL — either inline as `(https://...)` after the claim, or as a footnote-style `[^n]` with URLs listed at the bottom. No naked assertions.
 
-If your final message has no tool call and no text, the parent treats the research as failed — don't do that. Always emit the report, even if it's a short "I couldn't find useful material because …" summary.
+At termination, the parent agent reads `RESEARCH.md` from disk — that file IS the report. Keep your terminating message brief (a one-line "done" plus caveats if any); do not duplicate the report in chat.
+
+## Be comprehensive
+Research as comprehensively as possible. Map the landscape with `web_research`, deep-read every URL that meaningfully informs the question, follow citations and markdown links inside fetched pages, and use `bash` (`python -c "..."`) to verify any empirical claim you can. Don't stop early. The parent agent values thoroughness over speed.
 """  # noqa: E501
 
 
 def build_user(instruction: str) -> str:
     return f"""{instruction}
 
-Use `web_research` to discover URLs, then `web_fetch` to read the most relevant pages. Use `bash` (e.g. `python -c "..."`) when you need to compute or probe something. Return your findings as a self-contained markdown report with URL citations for every concrete claim.
+Use `web_research` to discover URLs, then `web_fetch` to read the most relevant pages. Use `bash` (e.g. `python -c "..."`) when you need to compute or probe something. Populate `RESEARCH.md` with your findings as you go (URL citations for every concrete claim) — at termination the parent reads that file.
 """

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -168,3 +168,97 @@ def test_render_tool_record_markdown_error_path():
     )
     assert "# web_research #2" in rendered
     assert "**ERROR:** exa down" in rendered
+
+
+# ---------------------------------------------------------------------------
+# RESEARCH.md scaffold + return-value contract
+# ---------------------------------------------------------------------------
+
+
+def _terminating_response():
+    """Build a fake call_llm response whose only part has no function_call."""
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(function_call=None)],
+                    model_dump=lambda **_: {
+                        "role": "model",
+                        "parts": [{"text": "done"}],
+                    },
+                )
+            )
+        ],
+        text="done",
+    )
+
+
+def test_run_creates_research_md_scaffold(monkeypatch, tmp_path):
+    """run() scaffolds RESEARCH.md as `# {instruction}\\n` and returns its
+    contents — even if the agent never modifies it (terminates immediately)."""
+    monkeypatch.setattr(research_module, "_TASK_ROOT", tmp_path)
+    monkeypatch.setattr(research_module, "should_compact", lambda _: False)
+    monkeypatch.setattr(
+        research_module, "call_llm", lambda **_: (_terminating_response(), 100)
+    )
+
+    agent = research_module.ResearcherAgent("slug", "run-1", 1)
+    instruction = "Research how to fine-tune Llama on Modal"
+    result = agent.run(instruction)
+
+    research_md = tmp_path / "slug" / "run-1" / "research_1" / "RESEARCH.md"
+    assert research_md.exists()
+    assert research_md.read_text(encoding="utf-8") == f"# {instruction}\n"
+    # The framework ALWAYS returns RESEARCH.md from disk — never the LLM text.
+    assert result == f"# {instruction}\n"
+
+
+def test_run_returns_research_md_contents_when_populated(monkeypatch, tmp_path):
+    """If the agent populates RESEARCH.md via write_file, run() returns the
+    populated content (not the scaffold, not the terminating LLM text)."""
+    from tools import filesystem as fs_module
+
+    monkeypatch.setattr(research_module, "_TASK_ROOT", tmp_path)
+    monkeypatch.setattr(research_module, "should_compact", lambda _: False)
+    monkeypatch.setattr(fs_module, "_ALLOWED_ROOTS", [tmp_path.resolve()])
+
+    research_md_path = tmp_path / "slug" / "run-1" / "research_1" / "RESEARCH.md"
+    populated = "# done\n\nFinding: foo is bar (https://example.com).\n"
+
+    call_count = [0]
+
+    def fake_call_llm(**_):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            fc = SimpleNamespace(
+                name="write_file",
+                args={"path": str(research_md_path), "content": populated},
+                id="call_1",
+            )
+            return (
+                SimpleNamespace(
+                    candidates=[
+                        SimpleNamespace(
+                            content=SimpleNamespace(
+                                parts=[SimpleNamespace(function_call=fc)],
+                                model_dump=lambda **_: {
+                                    "role": "model",
+                                    "parts": [{"function_call": {"name": "write_file"}}],
+                                },
+                            )
+                        )
+                    ],
+                    text=None,
+                ),
+                100,
+            )
+        return _terminating_response(), 100
+
+    monkeypatch.setattr(research_module, "call_llm", fake_call_llm)
+
+    agent = research_module.ResearcherAgent("slug", "run-1", 1)
+    result = agent.run("any instruction")
+
+    assert research_md_path.read_text(encoding="utf-8") == populated
+    assert result == populated
+    assert call_count[0] == 2


### PR DESCRIPTION
## Summary

Make `RESEARCH.md` a first-class Researcher artifact and drop prescriptive numeric guidance from the prompt.

- **`agents/researcher.py`** — scaffolds `RESEARCH.md` at run start with a single H1 (`# {instruction}\n`) so the agent has a known target. The framework now ALWAYS reads `RESEARCH.md` from disk at termination and returns its contents — no fallback to the LLM's terminating message, no separate `PLAN_<iter>.md` file. Module + `run()` docstrings updated.
- **`prompts/research.py`** — strip prescriptive numbers ("Default 10, max 20.", "2-5 URLs", "Prefer 3 deep fetches over 10 shallow ones"). Replace the old "Output contract" section with "RESEARCH.md is your deliverable" + "Be comprehensive". Update Scope and Available-tools blocks to reference `write_file` / `edit_file` (now in the palette per #274). Update the user message to point at `RESEARCH.md`.
- **`tests/test_researcher.py`** — two new tests covering the contract:
  - `test_run_creates_research_md_scaffold` — terminate-immediately stub creates the H1 scaffold and `run()` returns exactly that string.
  - `test_run_returns_research_md_contents_when_populated` — agent calls `write_file` to populate `RESEARCH.md`; `run()` returns the populated content.

Net effect: the report is built up over the run instead of dumped at exit, and the prompt encourages depth without numeric ceilings.

## Test plan

- [x] `pytest tests/test_researcher.py -v` — 10/10 pass (2 new + 8 existing).
- [x] `pytest tests/ --ignore=tests/test_helpers.py` — 60/60 pass.
- [x] `grep -nE '\b[0-9]+\b' prompts/research.py` — no numeric guidance remains.
- [ ] Out-of-band manual smoke (next research call): confirm the agent calls `write_file`/`edit_file` against `RESEARCH.md` during the run, and the returned markdown matches the file contents.

## Out of scope

- Renaming `research_<iter>` → `research_v<version>` (parked for a possible future small rename PR).
- Per-call audit records under `research_<iter>/web_research/{seq}.md` and `web_fetch/{seq}.md` are unchanged.
- DeveloperAgent rewrite (#221) — separate, larger work.