### PR TITLE
scaffold MAIN.md as MainAgent's living plan

### DIFF
--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -6,9 +6,11 @@ memory ops (`add_idea` / `remove_idea` / `update_idea`). No termination in
 software — user SIGKILLs the process when satisfied.
 
 Session-level context: `GOAL.md` (only in MainAgent's own system prompt —
-subagents receive task-scoped strings via `idea` / `instruction` / `query`)
-and `task/<slug>/<run_id>/ideas/INDEX.md` (always-resident, regenerated
-after every idea-pool mutation).
+subagents receive task-scoped strings via `idea` / `instruction` / `query`),
+`task/<slug>/<run_id>/ideas/INDEX.md` (always-resident, regenerated after
+every idea-pool mutation), and `task/<slug>/<run_id>/MAIN.md` (the agent's
+living plan — scaffolded with `# {goal_text}`, maintained by the agent
+via `write_file` / `edit_file`).
 """
 
 from __future__ import annotations
@@ -77,6 +79,7 @@ class MainAgent:
         self.base_dir = _TASK_ROOT / slug / run_id
         self.ideas_dir = self.base_dir / "ideas"
         self.chat_log = self.base_dir / "main_agent_chat.jsonl"
+        self.main_md_path = self.base_dir / "MAIN.md"
         self.ideas_dir.mkdir(parents=True, exist_ok=True)
         self.dev_iter = 0
         self.research_iter = 0
@@ -100,6 +103,11 @@ class MainAgent:
         # Ensure INDEX.md exists so `load_index` has something to read.
         if not (self.ideas_dir / "INDEX.md").exists():
             (self.ideas_dir / "INDEX.md").write_text("# Idea pool\n\n")
+        # Scaffold MAIN.md — the agent's living plan, maintained via write_file
+        # / edit_file. Idempotent guard so re-instantiation in the same run dir
+        # doesn't clobber accumulated state.
+        if not self.main_md_path.exists():
+            self.main_md_path.write_text(f"# {goal_text}\n", encoding="utf-8")
 
     @weave.op()
     def run(self) -> None:

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -39,6 +39,8 @@ Be bold — a turn with 3-4 parallel calls is a normal, encouraged pattern. Hesi
 - `glob_files(root, pattern)` — list files matching a glob under `root` (e.g. find every `train_stats.json` under `task/<slug>/<run_id>/`).
 - `grep_code(root, pattern, file_glob?, max_results?)` — recursive regex search; cheap way to grep for a function name or leakage pattern across the run directory.
 - `list_dir(path, max_entries?)` — directory listing with `/` suffix on subdirectories.
+- `write_file(path, content)` — write a file (creates parent dirs, overwrites). Primary use: `MAIN.md` initial structure or full rewrites.
+- `edit_file(path, old_string, new_string, replace_all?)` — exact-string replacement. Primary use: incremental updates to `MAIN.md`.
 - `bash(command)` — run a shell command via `bash -c` (pipes, redirection, chaining all work). Every command is judged by an LLM safety judge first; destructive operations (`rm -rf /`, `dd`, `mkfs`, fork bombs, pipe-to-shell, writes to system paths, force-pushes, shutdown) are blocked. Use it for the long tail of operations the dedicated tools don't cover — `cp`, `mv`, `mkdir`, project-scoped `rm`, `tar`, `pip install`, `python -c "..."`, `python script.py | tee log`. **This is also your tool for inspection scripting** — run `python -c "..."` for any quick computation you used to do via a Python snippet, or `python /tmp/script.py` for longer probes.
 
 # CRITICAL: do not do the developer's job yourself
@@ -66,6 +68,10 @@ The default pattern after each `developer(idea=...)` call:
 4. Pick the next idea and call `develop` again — or call `research` first if you need grounding.
 
 You're free to call `research` / inspection tools / memory ops zero or many times between developer calls — whatever the current state needs. But do not call `develop` back-to-back without at least inspecting the prior result.
+
+# MAIN.md is your living plan
+
+A scaffolded `MAIN.md` already exists at the root of your run directory. **You must populate it.** Use `write_file` for the initial structure or full rewrites, `edit_file` to slot in updates as the run progresses. Maintain it as a living document throughout the run — your strategy, what you've tried, what came back, what's next — not as a passive file you never come back to.
 
 # Termination
 

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -317,3 +317,30 @@ def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatc
     records = [json.loads(line) for line in agent.chat_log.read_text().splitlines()]
     assert len(records) == 1
     assert records[0]["role"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# MAIN.md scaffold (mirrors the RESEARCH.md pattern from #275)
+# ---------------------------------------------------------------------------
+
+
+def test_init_creates_main_md_scaffold(patched_main_agent):
+    """Constructing MainAgent scaffolds MAIN.md with `# {goal_text}\\n`."""
+    goal = "win the competition by Friday"
+    agent = MainAgent(slug="test", run_id="r1", goal_text=goal)
+
+    assert agent.main_md_path == agent.base_dir / "MAIN.md"
+    assert agent.main_md_path.exists()
+    assert agent.main_md_path.read_text(encoding="utf-8") == f"# {goal}\n"
+
+
+def test_init_does_not_clobber_existing_main_md(patched_main_agent):
+    """Re-instantiating with the same (slug, run_id) leaves a populated MAIN.md untouched."""
+    base_dir = main_agent._TASK_ROOT / "test" / "r1"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    populated = "# done\n\n## What I tried\n\n- Idea 1: failed.\n"
+    (base_dir / "MAIN.md").write_text(populated, encoding="utf-8")
+
+    agent = MainAgent(slug="test", run_id="r1", goal_text="ignored on second construct")
+
+    assert agent.main_md_path.read_text(encoding="utf-8") == populated


### PR DESCRIPTION
## Summary

Port the `RESEARCH.md` pattern (#275) to MainAgent under the name `MAIN.md`. The framework scaffolds a single-line H1 file at the run directory root; the agent maintains it via `write_file` / `edit_file` throughout the run; the file is the agent's living plan.

- **`agents/main_agent.py`** — add `self.main_md_path = self.base_dir / "MAIN.md"`. In `__init__`, scaffold `MAIN.md` with `f"# {goal_text}\n"` next to the existing `INDEX.md` scaffold (idempotent guard). Module docstring updated.
- **`prompts/main_agent.py`** — list `write_file` / `edit_file` in the tool palette (already wired into the LLM via `*get_filesystem_tools()`, but the prompt advertised only the read-only set). Add a single-paragraph "MAIN.md is your living plan" section between Intended rhythm and Termination, mirroring `prompts/research.py:49-51` in shape and brevity.
- **`tests/test_main_agent.py`** — two tests: scaffold is created on construction, and re-instantiating with the same `(slug, run_id)` doesn't clobber an existing populated `MAIN.md`.

The structural asymmetry vs RESEARCH.md is read-back-at-termination: ResearcherAgent's `run()` returns `RESEARCH.md`'s contents because there's a parent (MainAgent) consuming it. MainAgent loops until SIGKILL — there is nowhere to return to — so the framework wiring is *scaffold only*.

`MAIN.md` is **not** auto-injected into MainAgent's system prompt; RESEARCH.md isn't injected into the researcher's prompt either. The agent self-consults via `read_file` if it needs to.

## Test plan

- [x] `pytest tests/test_main_agent.py -v` — 9/9 pass (2 new + 7 existing).
- [x] `pytest tests/ --ignore=tests/test_helpers.py` — 62/62 pass.
- [ ] Out-of-band manual smoke (next real session): confirm `task/<slug>/<run_id>/MAIN.md` is scaffolded with `# {goal_text}\n` at run start, and that the agent calls `write_file`/`edit_file` against it during the run.

## Out of scope

- Auto-injecting `MAIN.md` into the system prompt every step (would break prefix caching the same way `INDEX.md` already does).
- Reconsidering `INDEX.md`'s auto-injection — pre-existing; orthogonal.
- Cleaning up the stale `analyze (leaf)` mention in `agents/main_agent.py:4` (legacy from PR #271). Doc-only fix; separate.