### PR TITLE
rename developer artifacts to SOLUTION.{py,json,txt} and developer_v{N}/

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The original Kaggle pipeline: Researcher + Developer agents iterate on a competi
 Before running, create these files in `task/<slug>/`:
 
 - **`GOAL.md`**: Session-wide objective, threaded into every agent's system prompt.
-- **`description.md`**: Competition description and evaluation criteria (read by the developer's generated `train.py`).
+- **`description.md`**: Competition description and evaluation criteria (read by the developer's generated `SOLUTION.py`).
 
 The Main Agent bootstraps everything else — it writes ideas, research reports, and per-iteration developer outputs under `task/<slug>/<run_id>/` itself.
 
@@ -103,7 +103,7 @@ python launch_agent.py --slug "enter slug" --run-id my_run --goal-file path/to/G
 ### Monitoring
 
 - `task/<slug>/<run_id>/main_agent_chat.jsonl` — append-only audit log of every MainAgent step (assistant turn + tool result).
-- `task/<slug>/<run_id>/developer_<N>/<k>/` — per-attempt developer artifacts (`train.py`, `train.txt`, `train_stats.json`, `submission.csv`, …).
+- `task/<slug>/<run_id>/developer_v{N}/` — per-iteration developer artifacts (`SOLUTION.py`, `SOLUTION.txt`, `SOLUTION.json`, `submission.csv`, …).
 - `task/<slug>/<run_id>/research_<N>/` — per-call researcher artifacts (`PLAN_<N>.md` + `web_research/`/`web_fetch/` audit records).
 - `task/<slug>/<run_id>/ideas/` — idea pool (memdir-style `INDEX.md` + one file per idea).
 - Weights & Biases / Weave tracking is configured via `config.yaml` under `tracking.wandb`.

--- a/agents/developer.py
+++ b/agents/developer.py
@@ -1,10 +1,12 @@
 """DeveloperAgent stub.
 
-PR 1 (#270) stripped the legacy fenced-``python`` codegen contract. This PR
-drops the lingering helpers (``_find_previous_code``,
-``_load_custom_instructions``) that assumed a same-shape rewrite. A
-follow-up PR will replace this stub with a fresh codegen loop modeled on
-``ResearcherAgent.run()`` plus the new ``write_file`` / ``edit_file`` tools.
+#270 stripped the legacy fenced-``python`` codegen contract. #271 gutted
+the retry loop and orphaned helpers. This rename PR shifts the canonical
+artifacts from ``train.py`` / ``train_stats.json`` / ``developer_<iter>/``
+to ``SOLUTION.py`` / ``SOLUTION.json`` / ``developer_v{N}/``. A follow-up
+PR will replace this stub with a fresh flat tool loop modeled on
+``ResearcherAgent.run()`` plus the ``run_solution`` / filesystem /
+``web_search_stack_trace`` palette.
 
 Until then, ``run()`` raises ``NotImplementedError`` so a ``develop`` call
 from MainAgent surfaces a clean error.
@@ -42,7 +44,7 @@ class DeveloperAgent:
         self.run_id = run_id
         self.dev_iter = dev_iter
         self.conda_env = conda_env
-        self.base_dir = _TASK_ROOT / slug / run_id / f"developer_{dev_iter}"
+        self.base_dir = _TASK_ROOT / slug / run_id / f"developer_v{dev_iter}"
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
     @weave.op()

--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -55,7 +55,7 @@ _STUCK_NUDGE = (
     f"{_STUCK_REPEAT_THRESHOLD} turns. That's a sign you're out of ideas, not "
     "that the work is done. **Push on.** Concrete options: add a fresh idea "
     "via `add_idea`; call `research(instruction=\"...\")` to web-search for "
-    "unblocking ideas; inspect a `developer_N/` directory you haven't reviewed "
+    "unblocking ideas; inspect a `developer_v{N}/` directory you haven't reviewed "
     "yet; reread INDEX.md and pick the next-most-promising idea. **Never "
     "stop** — the session has no termination condition. The user will SIGKILL "
     "when satisfied."

--- a/prompts/bash_judge.py
+++ b/prompts/bash_judge.py
@@ -76,7 +76,7 @@ Block anything that could damage the host, escape the sandbox, exfiltrate secret
 - `cp src/foo.py dst/foo.py` — project-scoped copy.
 - `mkdir -p task/abc/run_1/scripts` — project-scoped directory creation.
 - `rm -rf task/abc/run_1/scripts` — project-scoped recursive delete.
-- `python train.py --epochs 5 > logs/train.log 2>&1` — exec + redirect to project path.
+- `python SOLUTION.py --epochs 5 > logs/train.log 2>&1` — exec + redirect to project path.
 - `grep -rn 'foo' src/ | head -50` — pipe of read-only commands.
 - `git add -A && git commit -m 'wip'` — local git mutation.
 - `tar czf out.tgz dir/` — archive a project dir.

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -30,13 +30,13 @@ Be bold — a turn with 3-4 parallel calls is a normal, encouraged pattern. Hesi
 
 # Your tool palette
 
-- `develop(idea_id?: int)` — subagent; writes and runs a `train.py`, retries internally until it produces `train_stats.json`. Returns `{{status, code, code_path, summary: {{score, stats, stdout_tail, attempts_made, final_error}}}}`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself. **Parallel-friendly:** call `develop` several times in one turn with different `idea_id`s to explore multiple ideas in parallel — strongly preferred over sequential exploration whenever ideas are independent.
+- `develop(idea_id?: int)` — subagent; writes and runs a `SOLUTION.py`, retries internally until it produces `SOLUTION.json`. Returns `{{status, code, code_path, summary: {{score, stats, stdout_tail, attempts_made, final_error}}}}`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself. **Parallel-friendly:** call `develop` several times in one turn with different `idea_id`s to explore multiple ideas in parallel — strongly preferred over sequential exploration whenever ideas are independent.
 - `researcher(instruction: str)` — subagent; web-grounded research with `web_fetch` + `web_search` and a `bash` shell for analysis/probing. Returns a markdown report with URL citations. Use for domain grounding, library docs, empirical sniff-tests on data. Parallel-friendly across orthogonal queries.
 - `add_idea(title: str, description: str)` — add an entry to the pool; returns the assigned integer id. INDEX.md above regenerates automatically.
 - `remove_idea(idea_id: int)` — remove a dead idea.
 - `update_idea(idea_id: int, description: str)` — revise an existing idea's body. Title stays.
-- `read_file(path, start_line?, end_line?)` — read a file with line numbers. Use this for quick file inspection (a `train.py` from a prior `developer_N/` run, a `valid_preds.csv` header, an idea body).
-- `glob_files(root, pattern)` — list files matching a glob under `root` (e.g. find every `train_stats.json` under `task/<slug>/<run_id>/`).
+- `read_file(path, start_line?, end_line?)` — read a file with line numbers. Use this for quick file inspection (a `SOLUTION.py` from a prior `developer_v{{N}}/` run, a `valid_preds.csv` header, an idea body).
+- `glob_files(root, pattern)` — list files matching a glob under `root` (e.g. find every `SOLUTION.json` under `task/<slug>/<run_id>/`).
 - `grep_code(root, pattern, file_glob?, max_results?)` — recursive regex search; cheap way to grep for a function name or leakage pattern across the run directory.
 - `list_dir(path, max_entries?)` — directory listing with `/` suffix on subdirectories.
 - `write_file(path, content)` — write a file (creates parent dirs, overwrites). Primary use: `MAIN.md` initial structure or full rewrites.
@@ -52,9 +52,9 @@ When what you want is "produce the thing we'd submit", call `develop(idea=...)` 
 You cannot assume any subagent is 100% correct. Every subagent result — especially `develop` — must be reviewed before you accept it.
 
 When `develop` returns `status="success"`:
-- Read the `code` field. Did the `train.py` actually implement the idea you gave it, or did it drift?
+- Read the `code` field. Did the `SOLUTION.py` actually implement the idea you gave it, or did it drift?
 - Check `summary.score` against `summary.stats`. Does the score line up with the internal validation metrics? Does it look suspiciously perfect (leakage)?
-- Spot-check via `read_file` / `bash` (`python -c "..."`) / `grep_code`: read sibling artifacts at `code_path`'s directory (e.g. `valid_preds.csv`, `train.txt`), reproduce the score, grep the code for common leakage patterns (`train.merge(test)`, fitting a scaler on full data before the split, fillna with statistics computed across train+test).
+- Spot-check via `read_file` / `bash` (`python -c "..."`) / `grep_code`: read sibling artifacts at `code_path`'s directory (e.g. `valid_preds.csv`, `SOLUTION.txt`), reproduce the score, grep the code for common leakage patterns (`train.merge(test)`, fitting a scaler on full data before the split, fillna with statistics computed across train+test).
 - If anything's fishy: add a remediation idea to the pool describing what to fix, and deprioritize or remove the current idea.
 
 When `research` returns a markdown report: URLs are guaranteed to exist and have been read, but the subagent's conclusions are not independently verified. If you're about to build on a claim, spot-check the key parts via `bash` / `read_file` or another `research` call.

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -376,10 +376,10 @@ def get_main_agent_tools():
             name="develop",
             description=(
                 "Runs one developer iteration and OWNS SUBMISSION AUTHORING: the "
-                "developer subagent writes a `train.py` that produces whatever "
+                "developer subagent writes a `SOLUTION.py` that produces whatever "
                 "artifact the session goal requires (CSV, ONNX graph, model "
                 "weights, generated text, ZIP bundle, …) and dumps "
-                "`train_stats.json` with a score. Retries internally until "
+                "`SOLUTION.json` with a score. Retries internally until "
                 "valid stats land. Returns a structured payload with the final "
                 "code, its path on disk, and a summary (score, stats, "
                 "stdout_tail, attempts_made). Omit `idea_id` on the very first "

--- a/utils/output.py
+++ b/utils/output.py
@@ -23,7 +23,7 @@ def truncate_for_llm(
 
     If *full_output_path* is given and the file does not already exist, the
     full text is written there. If it already exists (e.g. the caller wrote
-    ``train.txt`` before calling this), the write is skipped — the path is
+    ``SOLUTION.txt`` before calling this), the write is skipped — the path is
     only used in the truncation reference message.
     """
     if len(text) <= max_chars:


### PR DESCRIPTION
## Summary

Mechanical rename ahead of the DeveloperAgent rewrite (issue #221). No behavior change — `DeveloperAgent.run()` still raises `NotImplementedError`. Reviewable as a string-rename diff.

| Old | New |
|---|---|
| `train.py` | `SOLUTION.py` |
| `train_stats.json` | `SOLUTION.json` |
| `train.txt` | `SOLUTION.txt` |
| Directory: `developer_<iter>/` | `developer_v{N}/` |

The `dev_iter` / `research_iter` field names stay — only the directory string carries the `_v` prefix.

## Files touched

- `agents/developer.py` — base_dir format string + module docstring
- `agents/main_agent.py` — `_STUCK_NUDGE` example
- `prompts/main_agent.py` — `develop` description, `read_file` / `glob_files` examples, review checklist
- `prompts/bash_judge.py` — example bash command
- `utils/llm_utils.py` — `develop` LLM tool description
- `utils/output.py` — docstring example
- `README.md` — directory listing + description.md note

## Out of scope (lands in PR B — the rewrite)

- New `run_solution` tool, flat tool loop in `run()`, `prompts/developer.py`, `get_developer_tools()` factory.
- Return-shape change (`code_path` → `version_dir`, drop `code` / `stdout_tail`, rename `attempts_made` → `runs_made`, add `report` from SOLUTION.md).
- `SOLUTION.py` / `SOLUTION.md` scaffolds, FileHandler guardrail extension.
- Old archived `developer_<iter>/train.py` directories on disk (not migrated).

## Tests

`pytest tests/ --ignore=tests/test_helpers.py` — 63/63 green.