### PR TITLE
rewrite DeveloperAgent as flat tool loop over run_solution + filesystem palette

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -1,37 +1,134 @@
-"""DeveloperAgent stub.
+"""Developer sub-agent — flat tool loop over `run_solution` + filesystem palette.
 
-#270 stripped the legacy fenced-``python`` codegen contract. #271 gutted
-the retry loop and orphaned helpers. This rename PR shifts the canonical
-artifacts from ``train.py`` / ``train_stats.json`` / ``developer_<iter>/``
-to ``SOLUTION.py`` / ``SOLUTION.json`` / ``developer_v{N}/``. A follow-up
-PR will replace this stub with a fresh flat tool loop modeled on
-``ResearcherAgent.run()`` plus the ``run_solution`` / filesystem /
-``web_search_stack_trace`` palette.
+Mirrors ResearcherAgent in shape: construct with ``(slug, run_id, dev_iter)``
+and call ``run(idea)`` to author SOLUTION.py + SOLUTION.md, execute the
+script under guardrails + LLM monitor via ``run_solution``, debug failures
+with ``web_search_stack_trace``, maintain SOLUTION.md as a living plan, and
+return a structured report read back from SOLUTION.md at termination.
 
-Until then, ``run()`` raises ``NotImplementedError`` so a ``develop`` call
-from MainAgent surfaces a clean error.
+Per-invocation layout (owned by this module):
+
+    task/<slug>/<run_id>/developer_v{dev_iter}/
+    ├── SOLUTION.py    # agent-authored training script — scaffolded with the
+    │                  # logging stanza at __init__; agent edits below it
+    ├── SOLUTION.md    # the agent's living plan / report — scaffolded at
+    │                  # run() entry with `# {idea}\n`, populated via
+    │                  # write_file/edit_file, read back at termination
+    ├── SOLUTION.txt   # produced by SOLUTION.py's FileHandler at runtime
+    ├── SOLUTION.json  # produced by SOLUTION.py at end of run; required for
+    │                  # run_solution to flag success
+    └── submission.csv|.zip|...  # per-task submission artifact
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
 
 import weave
+from dotenv import load_dotenv
+from google.genai import types
 
 from project_config import get_config
+from prompts.developer import build_system, build_user
+from tools.developer import run_solution as tool_run_solution
+from tools.developer import web_search_stack_trace as tool_web_search_stack_trace
+from tools.filesystem import execute_filesystem_tool
+from tools.helpers import call_llm
+from utils.compact import compact_messages, should_compact
+from utils.llm_utils import append_message, get_developer_tools
+from utils.output import truncate_for_llm
 
+
+load_dotenv()
 
 logger = logging.getLogger(__name__)
 
 
 _CONFIG = get_config()
-_TASK_ROOT = Path(_CONFIG["paths"]["task_root"])
+_LLM_CFG = _CONFIG["llm"]
+_PATH_CFG = _CONFIG["paths"]
+
+_TASK_ROOT = Path(_PATH_CFG["task_root"])
+_DEVELOPER_LLM_MODEL = _LLM_CFG["developer_tool_model"]
+
+
+_SOLUTION_PY_SCAFFOLD = '''\
+"""SOLUTION.py — agent-authored training script.
+
+Edit below the logging stanza. Do not move or remove the basicConfig
+call — guardrails enforce that it precedes all third-party imports
+and registers a FileHandler for SOLUTION.txt.
+"""
+
+import logging
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(Path(__file__).parent / "SOLUTION.txt", mode="w"),
+    ],
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+# === third-party imports below this line ===
+'''
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+
+def _execute_tool_call(item, state: dict) -> str:
+    """Dispatch one function call from the agent's flat loop."""
+    args = dict(item.args)
+    tool_name = item.name
+
+    if tool_name == "run_solution":
+        result_json = tool_run_solution(state["base_dir"])
+        try:
+            parsed = json.loads(result_json)
+        except json.JSONDecodeError:
+            parsed = {}
+        state["runs_made"] = state.get("runs_made", 0) + 1
+        if parsed.get("success"):
+            state["last_score"] = parsed.get("score")
+            state["last_stats"] = parsed.get("stats", {})
+            state["final_error"] = None
+        else:
+            state["final_error"] = parsed.get("error_kind") or parsed.get("error")
+        elapsed = parsed.get("elapsed_seconds", 0.0) or 0.0
+        state["elapsed_total"] = state.get("elapsed_total", 0.0) + elapsed
+        return truncate_for_llm(result_json)
+
+    if tool_name == "web_search_stack_trace":
+        return truncate_for_llm(tool_web_search_stack_trace(args["query"]))
+
+    fs_result = execute_filesystem_tool(tool_name, args)
+    if fs_result is None:
+        raise ValueError(f"Unknown tool: {tool_name}")
+    return truncate_for_llm(fs_result)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
 
 
 class DeveloperAgent:
-    """Stub. Reborn in a follow-up PR."""
+    """Developer sub-agent — flat tool loop over run_solution + filesystem palette.
+
+    Construct with ``(slug, run_id, dev_iter, conda_env?)`` and call
+    ``run(idea)`` to author SOLUTION.py, execute it via run_solution,
+    debug failures, maintain SOLUTION.md, and return a structured report.
+    """
 
     def __init__(
         self,
@@ -45,11 +142,130 @@ class DeveloperAgent:
         self.dev_iter = dev_iter
         self.conda_env = conda_env
         self.base_dir = _TASK_ROOT / slug / run_id / f"developer_v{dev_iter}"
+        self.solution_py_path = self.base_dir / "SOLUTION.py"
+        self.solution_md_path = self.base_dir / "SOLUTION.md"
         self.base_dir.mkdir(parents=True, exist_ok=True)
+
+        if not self.solution_py_path.exists():
+            self.solution_py_path.write_text(
+                _SOLUTION_PY_SCAFFOLD, encoding="utf-8"
+            )
+
+    def _load_custom_instructions(self) -> str | None:
+        """Read ``task/<slug>/DEVELOPER_INSTRUCTIONS.md`` if it exists."""
+        path = _TASK_ROOT / self.slug / "DEVELOPER_INSTRUCTIONS.md"
+        if not path.exists():
+            return None
+        return path.read_text(encoding="utf-8")
 
     @weave.op()
     def run(self, idea: str) -> dict[str, Any]:
-        raise NotImplementedError(
-            "DeveloperAgent codegen is disabled. A follow-up PR will introduce "
-            "the new flat-loop codegen design."
+        """Run the developer flat tool loop and return a structured report.
+
+        Scaffolds ``SOLUTION.md`` with ``# {idea}\\n`` (idempotent), runs the
+        tool loop until the LLM returns a text-only response, reads
+        ``SOLUTION.md`` back as the report, and packages a return dict for
+        MainAgent.
+        """
+        if not self.solution_md_path.exists():
+            self.solution_md_path.write_text(f"# {idea}\n", encoding="utf-8")
+
+        logger.info(
+            "DeveloperAgent.run slug=%s run_id=%s dev_iter=%d dir=%s",
+            self.slug,
+            self.run_id,
+            self.dev_iter,
+            self.base_dir,
         )
+
+        system_prompt = build_system(
+            custom_instructions=self._load_custom_instructions(),
+        )
+        user_prompt = build_user(idea)
+        tools = get_developer_tools()
+        state: dict = {
+            "base_dir": self.base_dir,
+            "runs_made": 0,
+            "last_score": None,
+            "last_stats": {},
+            "final_error": None,
+            "elapsed_total": 0.0,
+        }
+        input_list: list[dict] = [append_message("user", user_prompt)]
+        last_input_tokens: int | None = None
+
+        step = 0
+        while True:
+            step += 1
+            logger.info("DeveloperAgent step %d", step)
+
+            if should_compact(last_input_tokens):
+                input_list = compact_messages(
+                    input_list, model=_DEVELOPER_LLM_MODEL
+                )
+
+            response, last_input_tokens = call_llm(
+                model=_DEVELOPER_LLM_MODEL,
+                system_instruction=system_prompt,
+                function_declarations=tools,
+                messages=input_list,
+                enable_google_search=False,
+                include_usage=True,
+            )
+
+            parts = response.candidates[0].content.parts
+            has_function_calls = any(
+                part.function_call
+                for part in parts
+                if hasattr(part, "function_call")
+            )
+
+            if not has_function_calls:
+                logger.info("DeveloperAgent completed at step %d", step)
+                break
+
+            function_responses = []
+            for part in parts:
+                if hasattr(part, "function_call") and part.function_call:
+                    tool_result_str = _execute_tool_call(part.function_call, state)
+                    function_responses.append(
+                        types.Part.from_function_response(
+                            name=part.function_call.name,
+                            response={"result": tool_result_str},
+                        )
+                    )
+
+            input_list.append(
+                response.candidates[0].content.model_dump(
+                    mode="json", exclude_none=True
+                )
+            )
+            if function_responses:
+                input_list.append(
+                    types.Content(
+                        role="function", parts=function_responses
+                    ).model_dump(mode="json", exclude_none=True)
+                )
+
+        report = self.solution_md_path.read_text(encoding="utf-8")
+        status = "success" if state["last_score"] is not None else "failed"
+        logger.info(
+            "DeveloperAgent.run finished slug=%s run_id=%s dev_iter=%d status=%s",
+            self.slug,
+            self.run_id,
+            self.dev_iter,
+            status,
+        )
+
+        return {
+            "status": status,
+            "version_dir": str(self.base_dir),
+            "summary": {
+                "score": state["last_score"],
+                "stats": state["last_stats"],
+                "elapsed_seconds": state["elapsed_total"],
+                "runs_made": state["runs_made"],
+                "final_error": state["final_error"],
+            },
+            "report": report,
+        }

--- a/guardrails/developer.py
+++ b/guardrails/developer.py
@@ -200,6 +200,127 @@ Third-party libraries may configure logging on import, making basicConfig a no-o
     }
 
 
+# ----------------------------------------------------
+# Guardrails: SOLUTION.txt FileHandler in basicConfig
+# ----------------------------------------------------
+
+
+def _is_logging_filehandler_call(call: ast.Call) -> bool:
+    """Detect ``logging.FileHandler(...)`` calls."""
+    return (
+        isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "logging"
+        and call.func.attr == "FileHandler"
+    )
+
+
+def _ast_contains_string(node: ast.AST, target: str) -> bool:
+    """Return True if any Constant node within ``node``'s subtree equals ``target``."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Constant) and sub.value == target:
+            return True
+    return False
+
+
+def check_solution_txt_filehandler(code: str) -> dict:
+    """Ensure ``logging.basicConfig`` registers a ``FileHandler`` for SOLUTION.txt.
+
+    Walks the AST to find a top-level ``logging.basicConfig(handlers=[...])``
+    call whose handlers list contains ``logging.FileHandler(...)`` whose
+    arguments reference the literal string ``"SOLUTION.txt"``. The agent's
+    SOLUTION.py is required to self-log via this FileHandler so the curated
+    training log lands at ``Path(__file__).parent / "SOLUTION.txt"``.
+
+    Returns a ``{status, violations}`` dict shaped like
+    ``check_logging_basicconfig_order``.
+    """
+    try:
+        module = ast.parse(code)
+    except SyntaxError as exc:
+        return {
+            "status": "fail",
+            "violations": [
+                {
+                    "line": getattr(exc, "lineno", 0) or 0,
+                    "reason": f"syntax error while parsing generated code: {exc}",
+                }
+            ],
+        }
+
+    basic_calls = [
+        node
+        for node in module.body
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and _is_logging_basicconfig_call(node.value)
+    ]
+
+    if not basic_calls:
+        return {
+            "status": "fail",
+            "violations": [
+                {
+                    "line": 0,
+                    "reason": "No top-level logging.basicConfig() call found.",
+                }
+            ],
+        }
+
+    for call_expr in basic_calls:
+        call = call_expr.value
+        handlers_kw = next(
+            (kw for kw in call.keywords if kw.arg == "handlers"), None
+        )
+        if handlers_kw is None:
+            return {
+                "status": "fail",
+                "violations": [
+                    {
+                        "line": call.lineno,
+                        "reason": (
+                            "logging.basicConfig() must include a `handlers=[...]` "
+                            "kwarg registering a FileHandler for SOLUTION.txt."
+                        ),
+                    }
+                ],
+            }
+        if not isinstance(handlers_kw.value, ast.List):
+            return {
+                "status": "fail",
+                "violations": [
+                    {
+                        "line": handlers_kw.value.lineno,
+                        "reason": (
+                            "logging.basicConfig() `handlers=` must be a list "
+                            "literal of handler instances."
+                        ),
+                    }
+                ],
+            }
+        for handler_node in handlers_kw.value.elts:
+            if not isinstance(handler_node, ast.Call):
+                continue
+            if not _is_logging_filehandler_call(handler_node):
+                continue
+            if _ast_contains_string(handler_node, "SOLUTION.txt"):
+                return {"status": "pass", "violations": []}
+        return {
+            "status": "fail",
+            "violations": [
+                {
+                    "line": call.lineno,
+                    "reason": (
+                        "logging.basicConfig() `handlers=` must include a "
+                        '`logging.FileHandler(... "SOLUTION.txt" ...)` entry.'
+                    ),
+                }
+            ],
+        }
+
+    return {"status": "pass", "violations": []}
+
+
 # ----------------------------------------------
 # Guardrails: LLM-based data leakage risk review
 # ----------------------------------------------

--- a/prompts/developer.py
+++ b/prompts/developer.py
@@ -1,0 +1,96 @@
+"""Prompts for the Developer sub-agent.
+
+The Developer subagent receives an `idea` (markdown body) from MainAgent,
+authors `SOLUTION.py`, runs it under guardrails + an LLM training monitor
+via the `run_solution` tool, debugs failures with `web_search_stack_trace`
+and the standard filesystem palette, and maintains `SOLUTION.md` as a
+living plan. At termination the parent agent reads `SOLUTION.md` from
+disk as the report.
+"""
+
+from __future__ import annotations
+
+
+_LOGGING_STANZA = '''\
+import logging
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(Path(__file__).parent / "SOLUTION.txt", mode="w"),
+    ],
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+'''
+
+
+def build_system(custom_instructions: str | None = None) -> str:
+    custom_section = ""
+    if custom_instructions and custom_instructions.strip():
+        custom_section = (
+            "\n<custom_instructions>\n"
+            f"{custom_instructions.strip()}\n"
+            "</custom_instructions>\n\n"
+        )
+
+    return f"""You are Developer: a specialist sub-agent that implements an idea as a Python script (`SOLUTION.py`), executes it under guardrails + an LLM training monitor, debugs failures, and reports back to the parent agent.
+{custom_section}
+=== Scope ===
+Use `write_file` / `edit_file` to author `SOLUTION.py` and maintain `SOLUTION.md`; `run_solution` to execute the script under guardrails; `read_file` / `glob_files` / `grep_code` / `list_dir` for inspection; `bash` for sniff-tests, `pip install`, file ops; `web_search_stack_trace` to research a runtime traceback.
+
+## Available tools
+- `write_file(path, content)` / `edit_file(path, old_string, new_string, replace_all?)` — author/maintain `SOLUTION.py` and `SOLUTION.md`. Use `write_file` for the initial structure or full rewrites; `edit_file` for incremental updates.
+- `run_solution()` — execute `SOLUTION.py` at your working directory under static guardrails (basicConfig order + FileHandler check) and an LLM training monitor that watches stdout/stderr live. Returns `{{success, score, stats, killed_by_monitor, elapsed_seconds, output_tail}}` on success, or `{{success: false, error_kind, violations|error, output_tail?}}` on failure. The monitor kills the process on NaN loss, deadlock, OOM, etc. SOLUTION.txt is written by the script's own logger — read it via `read_file` for the curated training log.
+- `web_search_stack_trace(query: str)` — feed in a stack trace (raw stderr is fine; the function isolates the traceback) and get back the same trace annotated with a web-grounded suggested fix. Use only for traces you cannot fix from inspection alone.
+- `read_file(path, start_line?, end_line?)` / `glob_files(root, pattern)` / `grep_code(root, pattern, file_glob?, max_results?)` / `list_dir(path, max_entries?)` — read-only inspection. Use to read prior versions, library source, sibling artifacts.
+- `bash(command)` — run a shell command via `bash -c`. Use for sniff-tests (`python -c "..."`), `pip install`, file ops, archive creation. Destructive operations are blocked by an LLM safety judge.
+
+## SOLUTION.py contract
+
+Your `SOLUTION.py` is the script the framework executes when you call `run_solution`. It MUST start with this exact logging stanza, before any third-party imports:
+
+```python
+{_LOGGING_STANZA}```
+
+Then your training/inference logic below. A pre-execution guardrail enforces:
+1. `logging.basicConfig` precedes every third-party import — third-party libraries configure logging on import, making a later basicConfig a no-op.
+2. The `handlers=` list registers a `logging.FileHandler` whose first arg references the literal string `"SOLUTION.txt"`.
+
+Other hard constraints:
+- Use `logger.info(...)` / `logger.warning(...)` / `logger.error(...)` for all observability — the FileHandler curates these into `SOLUTION.txt`. Library prints and tracebacks still hit stderr (the LLM monitor sees them) but do not pollute `SOLUTION.txt`.
+- `SOLUTION.py` MUST write `Path(__file__).parent / "SOLUTION.json"` with at least `{{"score": <float>}}` at end of run. The framework uses `SOLUTION.json` to decide whether the run succeeded. No `SOLUTION.json` (or a non-finite score) = failed run. The `<idea>` may require additional keys — follow whatever schema it specifies.
+- Write any submission or auxiliary artifacts (`submission.csv`, `valid_preds.csv`, `submission.zip`, etc.) to `Path(__file__).parent` so they land alongside `SOLUTION.py`.
+- The framework prepends a `BASE_DIR` constant — use `BASE_DIR / "<file>"` to read competition data. Locally this resolves to `task/<slug>/`; on Kaggle to `/kaggle/input/<slug>/`.
+- Do not use `try/except` to suppress errors. Let exceptions propagate so they appear in stderr (the monitor sees them) and SOLUTION.txt (your logger sees them via `logger.exception` if you wrap a top-level handler).
+
+## SOLUTION.md is your living plan
+
+A scaffolded `SOLUTION.md` already exists at the root of your run directory. **You must populate it.** Use `write_file` for the initial structure or full rewrites, `edit_file` to slot in updates as the run progresses. Maintain it as a living document — your strategy, what you tried, what came back, what's next, and the final summary — not as a passive file you never come back to.
+
+At termination, the parent agent reads `SOLUTION.md` from disk — that file IS the report. Keep your terminating message brief (a one-line "done" plus caveats if any); do not duplicate the report in chat.
+
+## Rhythm
+
+1. Read the `<idea>` block (in the user prompt).
+2. Optionally inspect prior versions via `read_file` / `glob_files` (e.g. a prior `developer_v{{N}}/SOLUTION.py`).
+3. Author `SOLUTION.py` via `write_file` (the scaffold already has the logging stanza — edit below it).
+4. Call `run_solution()`. Read the returned `output_tail` for an error preview; read `SOLUTION.txt` via `read_file` for the curated log.
+5. On error: edit SOLUTION.py via `edit_file`, optionally call `web_search_stack_trace` if the trace is unfamiliar, then re-run.
+6. Update `SOLUTION.md` as you go.
+7. Terminate with a brief text-only response when satisfied.
+
+## Termination
+End your turn with a plain text response (no function call) to terminate. The framework reads `SOLUTION.md` and packages it as the report to the parent agent.
+"""  # noqa: E501
+
+
+def build_user(idea: str) -> str:
+    return f"""<idea>
+{idea}
+</idea>
+
+Author `SOLUTION.py` to implement the idea above. Run it with `run_solution()`. Maintain `SOLUTION.md` as your living plan throughout — at termination the parent agent reads that file.
+"""

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -30,7 +30,7 @@ Be bold — a turn with 3-4 parallel calls is a normal, encouraged pattern. Hesi
 
 # Your tool palette
 
-- `develop(idea_id?: int)` — subagent; writes and runs a `SOLUTION.py`, retries internally until it produces `SOLUTION.json`. Returns `{{status, code, code_path, summary: {{score, stats, stdout_tail, attempts_made, final_error}}}}`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself. **Parallel-friendly:** call `develop` several times in one turn with different `idea_id`s to explore multiple ideas in parallel — strongly preferred over sequential exploration whenever ideas are independent.
+- `develop(idea_id?: int)` — subagent; writes and runs a `SOLUTION.py` until it produces `SOLUTION.json` or terminates. Returns `{{status, version_dir, summary: {{score, stats, elapsed_seconds, runs_made, final_error}}, report}}` — `version_dir` is where `SOLUTION.{{py,md,json,txt}}` live; `report` is the developer's `SOLUTION.md`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself. **Parallel-friendly:** call `develop` several times in one turn with different `idea_id`s to explore multiple ideas in parallel — strongly preferred over sequential exploration whenever ideas are independent.
 - `researcher(instruction: str)` — subagent; web-grounded research with `web_fetch` + `web_search` and a `bash` shell for analysis/probing. Returns a markdown report with URL citations. Use for domain grounding, library docs, empirical sniff-tests on data. Parallel-friendly across orthogonal queries.
 - `add_idea(title: str, description: str)` — add an entry to the pool; returns the assigned integer id. INDEX.md above regenerates automatically.
 - `remove_idea(idea_id: int)` — remove a dead idea.
@@ -52,9 +52,10 @@ When what you want is "produce the thing we'd submit", call `develop(idea=...)` 
 You cannot assume any subagent is 100% correct. Every subagent result — especially `develop` — must be reviewed before you accept it.
 
 When `develop` returns `status="success"`:
-- Read the `code` field. Did the `SOLUTION.py` actually implement the idea you gave it, or did it drift?
+- Read the `report` field (the developer's `SOLUTION.md`). Did the developer's understanding of the idea match what you asked for, or did it drift?
+- `read_file` `version_dir/SOLUTION.py` to verify the script itself.
 - Check `summary.score` against `summary.stats`. Does the score line up with the internal validation metrics? Does it look suspiciously perfect (leakage)?
-- Spot-check via `read_file` / `bash` (`python -c "..."`) / `grep_code`: read sibling artifacts at `code_path`'s directory (e.g. `valid_preds.csv`, `SOLUTION.txt`), reproduce the score, grep the code for common leakage patterns (`train.merge(test)`, fitting a scaler on full data before the split, fillna with statistics computed across train+test).
+- Spot-check via `read_file` / `bash` (`python -c "..."`) / `grep_code`: read sibling artifacts in `version_dir` (e.g. `valid_preds.csv`, `SOLUTION.txt`), reproduce the score, grep the code for common leakage patterns (`train.merge(test)`, fitting a scaler on full data before the split, fillna with statistics computed across train+test).
 - If anything's fishy: add a remediation idea to the pool describing what to fix, and deprioritize or remove the current idea.
 
 When `research` returns a markdown report: URLs are guaranteed to exist and have been read, but the subagent's conclusions are not independently verified. If you're about to build on a claim, spot-check the key parts via `bash` / `read_file` or another `research` call.

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -1,16 +1,149 @@
-"""Unit tests for the DeveloperAgent stub."""
+"""Unit tests for the rewritten DeveloperAgent."""
 
 from __future__ import annotations
+
+import json
+from types import SimpleNamespace
 
 import pytest
 
 from agents import developer
-from agents.developer import DeveloperAgent
+from agents.developer import DeveloperAgent, _SOLUTION_PY_SCAFFOLD
 
 
-def test_run_raises_not_implemented(monkeypatch, tmp_path):
+def _fake_text(text: str):
+    """Build a text-only response (no function_call attribute on the part)."""
+    part = SimpleNamespace(text=text)
+    content = SimpleNamespace(parts=[part])
+    content.model_dump = lambda **_: {"role": "model", "parts": [{"text": text}]}
+    candidate = SimpleNamespace(content=content)
+    return SimpleNamespace(candidates=[candidate])
+
+
+def _fake_fc(name: str, **args):
+    """Build a single-function-call response."""
+    fc = SimpleNamespace(name=name, args=args)
+    part = SimpleNamespace(function_call=fc)
+    content = SimpleNamespace(parts=[part])
+    content.model_dump = lambda **_: {
+        "role": "model",
+        "parts": [{"function_call": {"name": name, "args": dict(args)}}],
+    }
+    candidate = SimpleNamespace(content=content)
+    return SimpleNamespace(candidates=[candidate])
+
+
+@pytest.fixture
+def patched_developer(monkeypatch, tmp_path):
     monkeypatch.setattr(developer, "_TASK_ROOT", tmp_path / "task")
+    return tmp_path
 
-    dev = DeveloperAgent(slug="test-slug", run_id="r1", dev_iter=1)
-    with pytest.raises(NotImplementedError, match="codegen is disabled"):
-        dev.run(idea="Produce a finite score.")
+
+def test_init_creates_solution_py_scaffold(patched_developer):
+    """Constructing DeveloperAgent scaffolds SOLUTION.py with the logging stanza."""
+    dev = DeveloperAgent(slug="test", run_id="r1", dev_iter=0)
+
+    assert dev.solution_py_path == dev.base_dir / "SOLUTION.py"
+    assert dev.solution_py_path.exists()
+    assert dev.solution_py_path.read_text(encoding="utf-8") == _SOLUTION_PY_SCAFFOLD
+
+
+def test_init_does_not_clobber_existing_solution_py(patched_developer):
+    """Re-instantiating with the same dev_iter leaves a populated SOLUTION.py untouched."""
+    base_dir = developer._TASK_ROOT / "test" / "r1" / "developer_v0"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    populated = "import logging\nlogging.basicConfig()\nimport torch\n"
+    (base_dir / "SOLUTION.py").write_text(populated, encoding="utf-8")
+
+    dev = DeveloperAgent(slug="test", run_id="r1", dev_iter=0)
+
+    assert dev.solution_py_path.read_text(encoding="utf-8") == populated
+
+
+def test_run_dispatches_run_solution_success(patched_developer, monkeypatch):
+    """run_solution success threads score/stats/elapsed into the return shape."""
+    dev = DeveloperAgent(slug="test", run_id="r1", dev_iter=0)
+
+    responses = iter([_fake_fc("run_solution"), _fake_text("done")])
+    monkeypatch.setattr(
+        developer, "call_llm", lambda **kwargs: (next(responses), 0)
+    )
+    fake_result = json.dumps(
+        {
+            "success": True,
+            "score": 0.42,
+            "stats": {"score": 0.42, "n": 100},
+            "elapsed_seconds": 12.3,
+            "output_tail": "log tail...",
+        }
+    )
+    monkeypatch.setattr(
+        developer, "tool_run_solution", lambda version_dir: fake_result
+    )
+
+    result = dev.run(idea="produce a baseline")
+
+    assert set(result.keys()) == {"status", "version_dir", "summary", "report"}
+    assert result["status"] == "success"
+    assert result["version_dir"] == str(dev.base_dir)
+    assert result["summary"] == {
+        "score": 0.42,
+        "stats": {"score": 0.42, "n": 100},
+        "elapsed_seconds": pytest.approx(12.3),
+        "runs_made": 1,
+        "final_error": None,
+    }
+    assert result["report"] == "# produce a baseline\n"
+
+
+def test_run_failed_run_solution_records_error_kind(patched_developer, monkeypatch):
+    """A failed run_solution call records final_error and yields status=failed."""
+    dev = DeveloperAgent(slug="test", run_id="r1", dev_iter=0)
+
+    responses = iter([_fake_fc("run_solution"), _fake_text("done")])
+    monkeypatch.setattr(
+        developer, "call_llm", lambda **kwargs: (next(responses), 0)
+    )
+    monkeypatch.setattr(
+        developer,
+        "tool_run_solution",
+        lambda version_dir: json.dumps(
+            {
+                "success": False,
+                "error_kind": "guardrail_basicconfig",
+                "violations": [{"line": 1, "reason": "..."}],
+            }
+        ),
+    )
+
+    result = dev.run(idea="test")
+
+    assert result["status"] == "failed"
+    assert result["summary"]["final_error"] == "guardrail_basicconfig"
+    assert result["summary"]["runs_made"] == 1
+    assert result["summary"]["score"] is None
+
+
+def test_run_loads_developer_instructions_when_present(patched_developer, monkeypatch):
+    """DEVELOPER_INSTRUCTIONS.md at task/<slug>/ is threaded into build_system."""
+    task_root = developer._TASK_ROOT
+    (task_root / "test").mkdir(parents=True, exist_ok=True)
+    (task_root / "test" / "DEVELOPER_INSTRUCTIONS.md").write_text(
+        "Always use mixed precision.\n", encoding="utf-8"
+    )
+
+    captured = {}
+
+    def fake_build_system(custom_instructions=None):
+        captured["custom_instructions"] = custom_instructions
+        return "system prompt"
+
+    monkeypatch.setattr(developer, "build_system", fake_build_system)
+    monkeypatch.setattr(
+        developer, "call_llm", lambda **kwargs: (_fake_text("done"), 0)
+    )
+
+    dev = DeveloperAgent(slug="test", run_id="r1", dev_iter=0)
+    dev.run(idea="test")
+
+    assert "mixed precision" in captured["custom_instructions"]

--- a/tests/test_logging_guardrail.py
+++ b/tests/test_logging_guardrail.py
@@ -1,6 +1,9 @@
 """Unit tests for the third-party-import check added to the logging guardrail."""
 
-from guardrails.developer import check_logging_basicconfig_order
+from guardrails.developer import (
+    check_logging_basicconfig_order,
+    check_solution_txt_filehandler,
+)
 
 
 def test_basicconfig_after_import_fails():
@@ -53,3 +56,56 @@ x = 1
     result = check_logging_basicconfig_order(code)
     assert result["status"] == "pass"
     assert result["basicConfig_line"] is None
+
+
+# ---------------------------------------------------------------------------
+# check_solution_txt_filehandler — SOLUTION.txt FileHandler in basicConfig
+# ---------------------------------------------------------------------------
+
+
+def test_filehandler_solution_txt_passes():
+    code = """\
+import logging
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(Path(__file__).parent / "SOLUTION.txt", mode="w"),
+    ],
+)
+"""
+    assert check_solution_txt_filehandler(code)["status"] == "pass"
+
+
+def test_filehandler_missing_handlers_kwarg_fails():
+    code = """\
+import logging
+logging.basicConfig(level=logging.INFO)
+"""
+    result = check_solution_txt_filehandler(code)
+    assert result["status"] == "fail"
+    assert "handlers=" in result["violations"][0]["reason"]
+
+
+def test_filehandler_wrong_filename_fails():
+    code = """\
+import logging
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[logging.FileHandler("WRONG.txt")],
+)
+"""
+    result = check_solution_txt_filehandler(code)
+    assert result["status"] == "fail"
+    assert "SOLUTION.txt" in result["violations"][0]["reason"]
+
+
+def test_filehandler_no_basicconfig_fails():
+    code = """\
+import logging
+"""
+    result = check_solution_txt_filehandler(code)
+    assert result["status"] == "fail"
+    assert "basicConfig" in result["violations"][0]["reason"]

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -69,15 +69,15 @@ def patched_main_agent(monkeypatch, tmp_path):
             dev_calls[-1]["idea"] = idea
             return {
                 "status": "success",
-                "code": "# fake",
-                "code_path": f"dev_{self.dev_iter}",
+                "version_dir": f"task/test/r1/developer_v{self.dev_iter}",
                 "summary": {
                     "score": 0.5,
                     "stats": {},
-                    "stdout_tail": "",
-                    "attempts_made": 1,
+                    "elapsed_seconds": 0.0,
+                    "runs_made": 1,
                     "final_error": None,
                 },
+                "report": f"# fake idea\n\nDev iter {self.dev_iter} fake report.\n",
             }
 
     monkeypatch.setattr(main_agent, "DeveloperAgent", FakeDeveloperAgent)

--- a/tools/developer.py
+++ b/tools/developer.py
@@ -22,6 +22,10 @@ from prompts.tools_developer import (
     log_monitor_system as prompt_log_monitor_system,
     log_monitor_user as prompt_log_monitor_user,
 )
+from guardrails.developer import (
+    check_logging_basicconfig_order,
+    check_solution_txt_filehandler,
+)
 from schemas.developer import LogMonitorVerdict, StackTraceSolution
 from utils.output import truncate_for_llm
 import weave
@@ -430,3 +434,123 @@ def execute_with_monitor(
     output = job.result()
     logger.info("Execution output captured for %s", code_path)
     return output
+
+
+# ---------------------------------------------------------------------------
+# run_solution: agent-facing tool that wraps guardrails + execute_with_monitor
+# ---------------------------------------------------------------------------
+
+
+@weave.op()
+def run_solution(version_dir: str | Path) -> str:
+    """Execute the agent's SOLUTION.py at ``version_dir`` under guardrails + monitor.
+
+    Pipeline: read SOLUTION.py → static guardrails (basicConfig order +
+    SOLUTION.txt FileHandler) → execute_with_monitor (subprocess + LLM
+    distress monitor) → parse SOLUTION.json. Returns a JSON string with
+    ``{success, score?, stats?, elapsed_seconds, output_tail}`` on success
+    or ``{success: False, error_kind, ...}`` on failure.
+
+    The agent reads ``SOLUTION.txt`` separately via ``read_file`` for the
+    curated log. ``output_tail`` here is a short slice of the captured
+    stdout/stderr stream — useful for crashes that never reached the
+    script's logger (e.g. import errors before basicConfig) and for the
+    monitor's kill diagnostic when it fires.
+    """
+    version_dir = Path(version_dir)
+    code_path = version_dir / "SOLUTION.py"
+
+    if not code_path.exists():
+        return json.dumps(
+            {
+                "success": False,
+                "error_kind": "missing_solution_py",
+                "error": (
+                    f"SOLUTION.py not found at {code_path}. Author it via "
+                    "write_file before calling run_solution."
+                ),
+            }
+        )
+
+    code = code_path.read_text(encoding="utf-8")
+
+    g_basic = check_logging_basicconfig_order(code)
+    if g_basic["status"] == "fail":
+        return json.dumps(
+            {
+                "success": False,
+                "error_kind": "guardrail_basicconfig",
+                "violations": g_basic["violations"],
+            }
+        )
+
+    g_handler = check_solution_txt_filehandler(code)
+    if g_handler["status"] == "fail":
+        return json.dumps(
+            {
+                "success": False,
+                "error_kind": "guardrail_filehandler",
+                "violations": g_handler["violations"],
+            }
+        )
+
+    start = time.monotonic()
+    output = execute_with_monitor(
+        code_path=str(code_path),
+        timeout_seconds=_BASELINE_CODE_TIMEOUT,
+        log_monitor_interval=_LOG_MONITOR_INTERVAL,
+        logger=logger,
+    )
+    elapsed = time.monotonic() - start
+    output_tail = truncate_for_llm(output, max_chars=4_000)
+
+    stats_path = version_dir / "SOLUTION.json"
+    if not stats_path.exists():
+        return json.dumps(
+            {
+                "success": False,
+                "error_kind": "no_stats",
+                "elapsed_seconds": elapsed,
+                "output_tail": output_tail,
+            }
+        )
+
+    try:
+        stats = json.loads(stats_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return json.dumps(
+            {
+                "success": False,
+                "error_kind": "invalid_stats_json",
+                "error": str(exc),
+                "elapsed_seconds": elapsed,
+                "output_tail": output_tail,
+            }
+        )
+
+    score = stats.get("score") if isinstance(stats, dict) else None
+    if (
+        not isinstance(score, (int, float))
+        or isinstance(score, bool)
+        or score != score  # NaN check
+        or score in (float("inf"), float("-inf"))
+    ):
+        return json.dumps(
+            {
+                "success": False,
+                "error_kind": "missing_or_nonfinite_score",
+                "stats": stats if isinstance(stats, dict) else None,
+                "elapsed_seconds": elapsed,
+                "output_tail": output_tail,
+            }
+        )
+
+    return json.dumps(
+        {
+            "success": True,
+            "score": float(score),
+            "stats": stats,
+            "elapsed_seconds": elapsed,
+            "output_tail": output_tail,
+        }
+    )

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -178,6 +178,66 @@ def get_deep_research_tools():
 
 
 # ---------------------------------------------------------------------------
+# Developer tools (run_solution + web_search_stack_trace + filesystem)
+# ---------------------------------------------------------------------------
+
+
+def get_developer_tools():
+    """Inner tool palette for the Developer sub-agent.
+
+    Two developer-specific tools — ``run_solution`` (executes the agent's
+    SOLUTION.py under guardrails + LLM monitor) and ``web_search_stack_trace``
+    (web-grounded debug helper) — plus the shared filesystem palette
+    (``read_file`` / ``glob_files`` / ``grep_code`` / ``list_dir`` / ``bash`` /
+    ``write_file`` / ``edit_file``).
+    """
+    return [
+        types.FunctionDeclaration(
+            name="run_solution",
+            description=(
+                "Execute SOLUTION.py at the agent's working directory under "
+                "static guardrails (basicConfig order + FileHandler check) "
+                "and an LLM training monitor that watches stdout/stderr live "
+                "for NaN loss, deadlock, OOM, etc. Returns a JSON object: on "
+                "success {success, score, stats, elapsed_seconds, output_tail}; "
+                "on failure {success: false, error_kind, violations|error, "
+                "elapsed_seconds?, output_tail?}. SOLUTION.txt is written by "
+                "the script's own logger — read it via read_file for the "
+                "curated training log; output_tail here is a short slice of "
+                "raw stdout/stderr useful for pre-logger crashes and monitor "
+                "kill diagnostics."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        types.FunctionDeclaration(
+            name="web_search_stack_trace",
+            description=(
+                "Research how to fix a Python error from a stack trace. Pass "
+                "the raw stderr (the function isolates the traceback) and "
+                "receive the same trace annotated with a web-grounded "
+                "suggested fix from a search-grounded LLM call. Use for "
+                "unfamiliar tracebacks; for tracebacks you can fix from "
+                "inspection alone, edit directly without calling this."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The stack trace text (raw stderr is fine).",
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        *get_filesystem_tools(),
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Filesystem + explore tools (scoped to runtime.explore_allowed_roots)
 # ---------------------------------------------------------------------------
 
@@ -379,10 +439,11 @@ def get_main_agent_tools():
                 "developer subagent writes a `SOLUTION.py` that produces whatever "
                 "artifact the session goal requires (CSV, ONNX graph, model "
                 "weights, generated text, ZIP bundle, …) and dumps "
-                "`SOLUTION.json` with a score. Retries internally until "
-                "valid stats land. Returns a structured payload with the final "
-                "code, its path on disk, and a summary (score, stats, "
-                "stdout_tail, attempts_made). Omit `idea_id` on the very first "
+                "`SOLUTION.json` with a score. Returns a structured payload "
+                "with `version_dir` (where SOLUTION.{py,md,json,txt} live), "
+                "a `summary` (score, stats, elapsed_seconds, runs_made, "
+                "final_error), and a `report` (the developer's SOLUTION.md). "
+                "Omit `idea_id` on the very first "
                 "call (baseline from the session goal); otherwise pass the "
                 "integer id of the entry you selected from INDEX.md (the "
                 "`[NNN]` prefix) — the framework resolves it to the full "


### PR DESCRIPTION
## Summary

Replace `DeveloperAgent` stub with a flat tool loop modeled on `ResearcherAgent`. Closes #221.

The agent receives an `idea` from MainAgent, authors `SOLUTION.py`, runs it under guardrails + an LLM training monitor via the new `run_solution` tool, debugs failures with `web_search_stack_trace`, and maintains `SOLUTION.md` as a living plan. At termination the framework reads `SOLUTION.md` from disk as the report — same pattern as RESEARCH.md (#275) and MAIN.md (#276).

Builds on top of #277 (the rename PR).

## Tool palette (9 tools)

7 from `get_filesystem_tools()` (read/glob/grep/list/bash/write/edit) + 2 developer-specific:

- **`run_solution()`** (no args) — wraps `guardrails → execute_with_monitor → SOLUTION.json parse`. Returns `{success, score, stats, elapsed_seconds, output_tail}` on success or `{success: false, error_kind, ...}` on failure.
- **`web_search_stack_trace(query)`** — web-grounded debug helper for unfamiliar tracebacks.

No per-iteration cap on tool calls — termination is text-only LLM response.

## SOLUTION.py self-logs to SOLUTION.txt

The agent's `SOLUTION.py` is required to register `logging.FileHandler(Path(__file__).parent / "SOLUTION.txt", mode="w")` in `basicConfig`. Its `logger.info(...)` lines land in `SOLUTION.txt` — the curated training log, free of library noise. stderr (with library prints, tracebacks) still flows to the LLM monitor.

A new AST guardrail (`check_solution_txt_filehandler`) sits next to the existing `check_logging_basicconfig_order` and is invoked by `run_solution` before execution.

## Scaffolds

- `__init__` writes `SOLUTION.py` with the logging stanza pre-filled (idempotent — won't clobber an existing populated file).
- `run(idea)` writes `SOLUTION.md` with `# {idea}\n` (idempotent — same).

## Return shape (replaces legacy)

```python
{
    "status": "success" | "failed",
    "version_dir": "task/<slug>/<run_id>/developer_v<N>",
    "summary": {
        "score": <float|None>,
        "stats": {...},
        "elapsed_seconds": <float>,
        "runs_made": <int>,
        "final_error": "<str>" | None,
    },
    "report": "<inlined SOLUTION.md>",
}
```

`code` and `stdout_tail` drop out (MainAgent reads sibling files from `version_dir` if it wants them). `attempts_made` → `runs_made` (counts `run_solution` calls, not retries).

## Files

- `agents/developer.py` — full rewrite (~250 lines)
- `prompts/developer.py` — new (~80 lines)
- `tools/developer.py` — `run_solution` (~120 lines added)
- `guardrails/developer.py` — `check_solution_txt_filehandler` (~120 lines added)
- `utils/llm_utils.py` — `get_developer_tools()` factory + `develop` description update
- `prompts/main_agent.py` — return-shape mentions in `develop` description + review checklist
- `tests/test_main_agent.py` — `FakeDeveloperAgent` updated to new return shape
- `tests/test_developer.py` — 5 tests (scaffold, idempotency, run_solution success path, run_solution failure path, DEVELOPER_INSTRUCTIONS loading)
- `tests/test_logging_guardrail.py` — 4 new tests for the FileHandler check

## Tests

`pytest tests/ --ignore=tests/test_helpers.py` — 71/71 green (was 63 on PR A; +8 net new).

## Out of scope

- LLM leakage review (the existing `llm_leakage_review` is not wired into `run_solution`; could add later if needed — keeps every `run_solution` call cheap for now).
- Migrating archived `developer_<iter>/train.py` directories from prior runs.