### PR TITLE
developer: distinguish status='no_run' from status='failed'

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -248,7 +248,12 @@ class DeveloperAgent:
                 )
 
         report = self.solution_md_path.read_text(encoding="utf-8")
-        status = "success" if state["last_score"] is not None else "failed"
+        if state["runs_made"] == 0:
+            status = "no_run"
+        elif state["last_score"] is not None:
+            status = "success"
+        else:
+            status = "failed"
         logger.info(
             "DeveloperAgent.run finished slug=%s run_id=%s dev_iter=%d status=%s",
             self.slug,

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -30,7 +30,7 @@ Be bold — a turn with 3-4 parallel calls is a normal, encouraged pattern. Hesi
 
 # Your tool palette
 
-- `develop(idea_id?: int)` — subagent; writes and runs a `SOLUTION.py` until it produces `SOLUTION.json` or terminates. Returns `{{status, version_dir, summary: {{score, stats, elapsed_seconds, runs_made, final_error}}, report}}` — `version_dir` is where `SOLUTION.{{py,md,json,txt}}` live; `report` is the developer's `SOLUTION.md`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself. **Parallel-friendly:** call `develop` several times in one turn with different `idea_id`s to explore multiple ideas in parallel — strongly preferred over sequential exploration whenever ideas are independent.
+- `develop(idea_id?: int)` — subagent; writes and runs a `SOLUTION.py` until it produces `SOLUTION.json` or terminates. Returns `{{status, version_dir, summary: {{score, stats, elapsed_seconds, runs_made, final_error}}, report}}` — `status` is one of `"success"` / `"failed"` / `"no_run"`; `version_dir` is where `SOLUTION.{{py,md,json,txt}}` live; `report` is the developer's `SOLUTION.md`. Omit `idea_id` on the very first call (baseline from the session goal); on subsequent calls pass the integer id of the idea you selected from INDEX.md above. **The developer owns submission authoring.** Whatever form the session goal's artifact takes — CSV, ONNX graph, model checkpoint, generated text, ZIP bundle — `develop` is the tool that produces it. Do not hand-roll submission artifacts yourself. **Parallel-friendly:** call `develop` several times in one turn with different `idea_id`s to explore multiple ideas in parallel — strongly preferred over sequential exploration whenever ideas are independent.
 - `researcher(instruction: str)` — subagent; web-grounded research with `web_fetch` + `web_search` and a `bash` shell for analysis/probing. Returns a markdown report with URL citations. Use for domain grounding, library docs, empirical sniff-tests on data. Parallel-friendly across orthogonal queries.
 - `add_idea(title: str, description: str)` — add an entry to the pool; returns the assigned integer id. INDEX.md above regenerates automatically.
 - `remove_idea(idea_id: int)` — remove a dead idea.
@@ -57,6 +57,11 @@ When `develop` returns `status="success"`:
 - Check `summary.score` against `summary.stats`. Does the score line up with the internal validation metrics? Does it look suspiciously perfect (leakage)?
 - Spot-check via `read_file` / `bash` (`python -c "..."`) / `grep_code`: read sibling artifacts in `version_dir` (e.g. `valid_preds.csv`, `SOLUTION.txt`), reproduce the score, grep the code for common leakage patterns (`train.merge(test)`, fitting a scaler on full data before the split, fillna with statistics computed across train+test).
 - If anything's fishy: add a remediation idea to the pool describing what to fix, and deprioritize or remove the current idea.
+
+When `develop` returns `status="no_run"`:
+- The developer terminated without ever calling `run_solution` (`summary.runs_made == 0`, no `SOLUTION.json` produced). Treat this as **"the agent did not execute the idea"**, NOT "the idea is bad".
+- Read the `report` (the developer's `SOLUTION.md`) — there is often useful exploration, dead-ends found, or partial probes you can build on.
+- Decide: retry the same idea with a sharper sub-scope (`update_idea` then `develop` again), refine into a smaller more-constrained idea, or shelve and move on. Do NOT silently discard.
 
 When `research` returns a markdown report: URLs are guaranteed to exist and have been read, but the subagent's conclusions are not independently verified. If you're about to build on a claim, spot-check the key parts via `bash` / `read_file` or another `research` call.
 

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -124,6 +124,22 @@ def test_run_failed_run_solution_records_error_kind(patched_developer, monkeypat
     assert result["summary"]["score"] is None
 
 
+def test_run_no_run_status_when_no_run_solution_called(patched_developer, monkeypatch):
+    """Agent terminating without calling run_solution returns status='no_run'."""
+    dev = DeveloperAgent(slug="test", run_id="r1", dev_iter=0)
+
+    monkeypatch.setattr(
+        developer, "call_llm", lambda **kwargs: (_fake_text("nothing to do"), 0)
+    )
+
+    result = dev.run(idea="explore-only")
+
+    assert result["status"] == "no_run"
+    assert result["summary"]["runs_made"] == 0
+    assert result["summary"]["score"] is None
+    assert result["summary"]["final_error"] is None
+
+
 def test_run_loads_developer_instructions_when_present(patched_developer, monkeypatch):
     """DEVELOPER_INSTRUCTIONS.md at task/<slug>/ is threaded into build_system."""
     task_root = developer._TASK_ROOT


### PR DESCRIPTION
**Stack: bottom; based on `main`.**

`DeveloperAgent.run` previously collapsed two distinct outcomes into `status="failed"`:

1. `run_solution` was invoked and the script failed (real failure signal — idea probably needs revision).
2. `run_solution` was never invoked at all (the agent terminated text-only without executing anything).

MainAgent's prompt only had a checklist for `status="success"` and treated everything else as a discard signal, so legitimate exploration work got thrown away alongside busted attempts.

This PR adds a third status — `"no_run"` — derived from the existing `state["runs_made"]` counter, with a sibling MainAgent checklist paragraph that tells it to **read the report and decide retry / refine / shelve**, not silently discard.

## Changes

- `agents/developer.py` — replace binary `success/failed` with tri-state `no_run/success/failed` (key on `state["runs_made"] == 0`).
- `prompts/main_agent.py` — add the `status` enum to the `develop` tool description; add a `status="no_run"` paragraph next to the existing `status="success"` checklist.
- `tests/test_developer.py` — new `test_run_no_run_status_when_no_run_solution_called`.

## Test plan

- [x] `pytest tests/test_developer.py -v` — green (5 prior + 1 new).
- [x] `pytest tests/ --ignore=tests/test_helpers.py` — full suite green.
- [ ] Manual smoke on next real run: a developer that explores without calling `run_solution` returns `status="no_run"`, and MainAgent's reaction follows the new checklist.
