### PR TITLE
main agent prompt: require self-contained subagent briefings

### DIFF
--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -55,6 +55,27 @@ Be bold — a turn with 3-4 parallel calls is a normal, encouraged pattern. Hesi
 
 When what you want is "produce the thing we'd submit", call `develop(idea=...)` and let the developer subagent do it inside its own retry loop. `bash` is for inspection and small ad-hoc probes, not for authoring submission artifacts.
 
+# CRITICAL: write self-contained briefings
+
+Subagents cannot see your conversation. The string you pass to `develop` (the idea body, set via `add_idea` / `update_idea`) or to `researcher` (the `instruction` arg) is the only context they get. **Brief them like a smart colleague who just walked into the room** — they haven't seen what you've tried, don't know which artifacts you've already inspected, don't understand why this particular thing matters now.
+
+When you author or revise an idea body:
+- Lead with the concrete artifact and a measurable pass bar. "Improve X" is a wish, not a spec.
+- **Use absolute filepaths, never bare basenames.** Apply this to baselines, libraries, sibling agent artifacts (e.g. `task/{slug}/<run_id>/developer_vN/SOLUTION.py:line`), inputs, and outputs.
+- Identify the exact files to read and the exact files to write. If borrowing a technique from a prior run or external source, name the source file + line range so the developer copies the working pattern instead of reinventing it.
+- Cross-check the idea against the task's hard constraints (any excluded operations, required output schema, scorer rejection rules, time/memory budgets — read them out of `GOAL.md` / `DEVELOPER_INSTRUCTIONS.md` / scorer source) **before** adding it to the pool. An idea that violates a constraint forces the developer to silently substitute, which usually lands on a worse variant than you'd pick.
+- State the validation procedure and the pass/fail bar.
+- No open "Wait, ..." questions, no hedging. Resolve uncertainty in MAIN.md or via `research` first; the idea body is a spec, not a thinking-out-loud document.
+
+When you write a `researcher` instruction:
+- State the exact question and the shape of the answer you want ("3-5 candidates with URLs", "API surface table", "code patch", "yes/no with one paragraph of justification"). "Look into X" yields hand-wavy reports.
+- Say what you've already ruled out so the researcher doesn't re-tread.
+- Give a length cap when one fits.
+
+**Never delegate understanding.** Do not write "based on your findings, fix this" or "explore the space and pick something" — those phrases push synthesis onto the subagent instead of doing it yourself. Synthesize first (in MAIN.md, in your own reasoning), then write a briefing that proves you understood.
+
+A hypothesis is not a spec. "Maybe X, or maybe Y, see if it works" is a thinking-aloud note that belongs in MAIN.md. "Modify file F at line N from `<old>` to `<new>`, validate via `<command>`, expect metric M ≤ T" is a spec. Idea bodies must be specs.
+
 # CRITICAL: verify subagent outputs
 
 You cannot assume any subagent is 100% correct. Every subagent result — especially `develop` — must be reviewed before you accept it.


### PR DESCRIPTION
**Stack: on top of** #284 **(top of stack).**

Adds a `# CRITICAL: write self-contained briefings` section to `prompts/main_agent.py`

**Why.** A live MainAgent run produced an idea body that proposed an excluded operation and ended in unresolved "Wait, ..." hesitations. The DeveloperAgent silently substituted a different op and authored a noticeably more complex variant of the trick than the cleanest known form. Both failures trace to the briefing being a hypothesis, not a spec.

**What's added** (between the existing "do not do the developer's job yourself" and "verify subagent outputs" criticals):

- "Brief them like a smart colleague who just walked into the room."
- Idea-body checklist: concrete artifact + measurable pass bar; absolute filepaths only; exact files to read / write; cross-check against task hard constraints (excluded ops, output schema, scorer rules) **before** adding to the pool; validation procedure + pass / fail bar; no open "Wait, ..." questions.
- `researcher` instruction guidance: exact question, expected answer shape, what's been ruled out, length cap.
- "Never delegate understanding" anti-pattern.
- Concrete contrast: hypothesis vs. spec.

Section is generic — no domain-specific content (no NeuroGolf, ONNX, or Kaggle wording).

## Test plan

- [x] `pytest tests/test_main_agent.py -v` — 9 passed.
- [x] `python -c "from prompts.main_agent import build_system; build_system('demo-comp', 'goal', '(empty)', '/tmp/run')"` — f-string interpolates cleanly (`{slug}` rendering verified in section).
- [ ] Land in next live run; confirm idea bodies start carrying absolute paths + constraint cross-checks.