### PR TITLE
agent prompts: require prose after every tool call (#287)

### DIFF
--- a/prompts/developer.py
+++ b/prompts/developer.py
@@ -93,6 +93,14 @@ At termination, the parent agent reads `SOLUTION.md` from disk — that file IS 
 
 ## Termination
 End your turn with a plain text response (no function call) to terminate. The framework reads `SOLUTION.md` and packages it as the report to the parent agent.
+
+## Communicating with the user
+
+Assume the user can't see most tool calls or thinking — only your text output.
+
+**After every tool result returns (`run_solution`, `web_search_stack_trace`, `read_file`, `glob_files`, `grep_code`, `list_dir`, `bash`, `write_file`, `edit_file`), your next response must begin with a 1-3 sentence text block stating: (1) what the result showed, (2) what you're doing next and why.** Then issue the next tool call(s). The text block is mandatory — there are no "routine" tool calls that skip it. Keep it brief: if you can say it in one sentence, don't use three. Do NOT narrate what you're about to do as filler ("I will now..." / "Let me check..."); state what the prior result told you, then act.
+
+The closing terminator at end-of-run is in addition to these mid-run text blocks, not a replacement for them.
 """  # noqa: E501
 
 

--- a/prompts/main_agent.py
+++ b/prompts/main_agent.py
@@ -108,7 +108,15 @@ You're free to call `research` / inspection tools / memory ops zero or many time
 
 A scaffolded `MAIN.md` already exists at the root of your run directory. **You must populate it.** Use `write_file` for the initial structure or full rewrites, `edit_file` to slot in updates as the run progresses. Maintain it as a living document throughout the run — your strategy, what you've tried, what came back, what's next — not as a passive file you never come back to.
 
+# Communicating with the user
+
+When sending text, you're writing for a person, not logging to a console. Assume the user can't see most tool calls or thinking — only your text output.
+
+**After every tool result returns, your next response must begin with a 1-3 sentence text block stating: (1) what the result showed, (2) what you're doing next and why.** Then issue the next tool call(s). The text block is mandatory — there are no "routine" tool calls that skip it. Keep it brief: if you can say it in one sentence, don't use three. Do NOT narrate what you're about to do as filler ("I will now..." / "Let me check..."); state what the prior result told you, then act.
+
+**After each `develop` return and each external evaluator submission result, the text block must additionally state**: `metric=<x>, delta=<x − prior_best>, decision=<keep|pivot|escalate>`. Then your next tool call must be `edit_file MAIN.md` appending one line in the format `<UTC timestamp> | <event> | metric=<x> | delta=<x − baseline> | decision=<keep|pivot|escalate>`. Only after that may you proceed to the next idea or action.
+
 # Termination
 
-There is no termination condition in software. The user stops the process when satisfied. Keep iterating — every call should materially advance toward the goal. Do not emit a plain text response; every step should be a tool call.
+There is no termination condition in software. The user stops the process when satisfied. Keep iterating — every call should materially advance toward the goal.
 """

--- a/prompts/research.py
+++ b/prompts/research.py
@@ -65,6 +65,14 @@ At termination, the parent agent reads `RESEARCH.md` from disk — that file IS 
 
 ## Be comprehensive
 Research as comprehensively as possible. Map the landscape with `web_research`, deep-read every URL that meaningfully informs the question, follow citations and markdown links inside fetched pages, and use `bash` (`python -c "..."`) to verify any empirical claim you can. Don't stop early. The parent agent values thoroughness over speed.
+
+## Communicating with the user
+
+Assume the user can't see most tool calls or thinking — only your text output.
+
+**After every tool result returns (`web_research`, `web_fetch`, `read_file`, `glob_files`, `grep_code`, `list_dir`, `bash`, `write_file`, `edit_file`), your next response must begin with a 1-3 sentence text block stating: (1) what the result showed (key findings, dead ends, surprising data), (2) what you're doing next and why.** Then issue the next tool call(s). The text block is mandatory — there are no "routine" tool calls that skip it. Keep it brief: if you can say it in one sentence, don't use three. Do NOT narrate what you're about to do as filler ("I will now..." / "Let me check..."); state what the prior result told you, then act.
+
+The closing terminator (the brief "done" message) is in addition to these mid-run text blocks, not a replacement for them.
 """  # noqa: E501
 
 


### PR DESCRIPTION
Fixes #287.

## Summary

The MainAgent, DeveloperAgent, and ResearcherAgent system prompts were structured to keep all three agents silent during work — `prompts/main_agent.py:113` absolutely prohibited prose, and the Developer / Researcher prompts allowed prose only as a closing-message terminator. In a 13-hour traced run, MainAgent emitted prose on 1 / 837 steps (0.12%), DeveloperAgent on 5 / 576 (0.87%, all closing messages), and ResearcherAgent on 1 / 19 (closing summary only). Codex CLI on similar work emits ~21% — roughly 500x denser. The cost: post-hoc reviewers can't tell what the agent observed or decided, score-vs-baseline comparisons go unwritten, and the only forced-text slot (end-of-run summary) drifts toward confabulation.

This PR replaces the silent-by-default rules with a per-tool-call narration rule on all three agents. After every tool result, the next response must begin with a 1-3 sentence text block stating what the result showed and what the agent is doing next. The wording is modeled on Claude Code's main-agent prompt (`claude-code/constants/prompts.ts:406-414`) — *"Assume the user can't see most tool calls or thinking — only your text output."*

For MainAgent specifically, the rule additionally requires a `metric / delta / decision` line after every `develop` return or external evaluator submission, plus a forced `edit_file MAIN.md` write with the same content. This converts score-vs-baseline comparison from aspiration to a forcing function — the previous run, MainAgent received Kaggle scores back ~6620–6641 (below its known baseline ~6645) and never wrote down the comparison, so it never pivoted decisively.

The existing closing-message-as-terminator rules in Developer/Researcher remain — they're how the framework reads the final report. The new rule supplements them, not replaces them.

## Changes

- `prompts/main_agent.py` — replace `# Termination` block (was: *"Do not emit a plain text response; every step should be a tool call."*) with a new `# Communicating with the user` section requiring per-tool-call prose, plus the `metric / delta / decision` forcing function and forced MAIN.md write after `develop` / submission events. The original `# Termination` block stays, minus the prohibition line.
- `prompts/developer.py` — insert `## Communicating with the user` section before the existing `## Termination` block, applying the same per-tool-call prose rule. Existing `End your turn with a plain text response (no function call) to terminate.` rule unchanged.
- `prompts/research.py` — same shape: insert `## Communicating with the user` section before `## RESEARCH.md is your deliverable`, with the per-tool-call prose rule. Existing brief-terminator rule unchanged.

All three sections share consistent wording: *"Assume the user can't see most tool calls or thinking — only your text output."* and the same anti-filler clause (*"Do NOT narrate what you're about to do as filler ('I will now...' / 'Let me check...'); state what the prior result told you, then act."*).

## Out of scope

- Flipping `include_thoughts=True` on the Gemini LLM client (was originally proposed in issue body fix c) — dropped at user direction. The visible-prose channel restored by this PR is sufficient as the audit surface.
- Structuring the Developer/Researcher closing-message format (was originally fix d) — superseded by the per-tool-call prose rule, which makes the closing message less load-bearing.

## Test plan

- [x] `pytest tests/test_main_agent.py tests/test_developer.py tests/test_researcher.py -v` — 25 passed (the fixtures mock `call_llm` and don't assert on prompt content, so the prompt-text edits don't break them).
- [ ] Live run smoke test once merged: spin up a short MainAgent run, inspect Weave trace. Expectations:
  - At least 50% of MainAgent steps emit a text part.
  - The step immediately after `develop` returns includes `metric=` and `delta=` substrings, and the next tool call is `edit_file` targeting `MAIN.md`.
  - Developer/Researcher traces also show ≥50% steps with text parts.
  - MAIN.md after the run contains timestamped `metric / delta / decision` lines, not a free-form victory speech.

Stack: top of `04-30-remove_analyze...` (#285).