### PR TITLE
persist developer/researcher chat to jsonl (#287)

### DIFF
--- a/agents/developer.py
+++ b/agents/developer.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -146,6 +147,7 @@ class DeveloperAgent:
         self.base_dir = _TASK_ROOT / slug / run_id / f"developer_v{dev_iter}"
         self.solution_py_path = self.base_dir / "SOLUTION.py"
         self.solution_md_path = self.base_dir / "SOLUTION.md"
+        self.chat_log = self.base_dir / "developer_chat.jsonl"
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
         if not self.solution_py_path.exists():
@@ -223,6 +225,12 @@ class DeveloperAgent:
                 if hasattr(part, "function_call")
             )
 
+            assistant_content = response.candidates[0].content.model_dump(
+                mode="json", exclude_none=True
+            )
+            input_list.append(assistant_content)
+            self._log({"role": "assistant", "content": assistant_content})
+
             if not has_function_calls:
                 logger.info("DeveloperAgent completed at step %d", step)
                 break
@@ -230,19 +238,23 @@ class DeveloperAgent:
             function_responses = []
             for part in parts:
                 if hasattr(part, "function_call") and part.function_call:
-                    tool_result_str = _execute_tool_call(part.function_call, state)
+                    fc = part.function_call
+                    name = fc.name
+                    args = dict(fc.args)
+                    tool_result_str = _execute_tool_call(fc, state)
                     function_responses.append(
                         types.Part.from_function_response(
-                            name=part.function_call.name,
+                            name=name,
                             response={"result": tool_result_str},
                         )
                     )
+                    self._log({
+                        "role": "tool",
+                        "name": name,
+                        "args": args,
+                        "result": tool_result_str,
+                    })
 
-            input_list.append(
-                response.candidates[0].content.model_dump(
-                    mode="json", exclude_none=True
-                )
-            )
             if function_responses:
                 input_list.append(
                     types.Content(
@@ -277,3 +289,8 @@ class DeveloperAgent:
             },
             "report": report,
         }
+
+    def _log(self, record: dict) -> None:
+        record["ts"] = datetime.now(timezone.utc).isoformat()
+        with self.chat_log.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 import weave
@@ -211,6 +212,7 @@ class ResearcherAgent:
         self.web_research_dir = self.research_dir / "web_research"
         self.web_fetch_dir = self.research_dir / "web_fetch"
         self.research_md_path = self.research_dir / "RESEARCH.md"
+        self.chat_log = self.research_dir / "researcher_chat.jsonl"
 
     def _load_custom_instructions(self) -> str | None:
         """Read `task/<slug>/RESEARCHER_INSTRUCTIONS.md` if it exists."""
@@ -293,6 +295,12 @@ class ResearcherAgent:
                 if hasattr(part, "function_call")
             )
 
+            assistant_content = response.candidates[0].content.model_dump(
+                mode="json", exclude_none=True
+            )
+            input_list.append(assistant_content)
+            self._log({"role": "assistant", "content": assistant_content})
+
             if not has_function_calls:
                 logger.info("ResearcherAgent completed at step %d", step)
                 break
@@ -300,19 +308,23 @@ class ResearcherAgent:
             function_responses = []
             for part in parts:
                 if hasattr(part, "function_call") and part.function_call:
-                    tool_result_str = _execute_tool_call(part.function_call, state)
+                    fc = part.function_call
+                    name = fc.name
+                    args = dict(fc.args)
+                    tool_result_str = _execute_tool_call(fc, state)
                     function_responses.append(
                         types.Part.from_function_response(
-                            name=part.function_call.name,
+                            name=name,
                             response={"result": tool_result_str},
                         )
                     )
+                    self._log({
+                        "role": "tool",
+                        "name": name,
+                        "args": args,
+                        "result": tool_result_str,
+                    })
 
-            input_list.append(
-                response.candidates[0].content.model_dump(
-                    mode="json", exclude_none=True
-                )
-            )
             if function_responses:
                 input_list.append(
                     types.Content(
@@ -327,3 +339,8 @@ class ResearcherAgent:
             len(report),
         )
         return report
+
+    def _log(self, record: dict) -> None:
+        record["ts"] = datetime.now(timezone.utc).isoformat()
+        with self.chat_log.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")


### PR DESCRIPTION
## Summary

Mirror MainAgent's `main_agent_chat.jsonl` persistence pattern on the two subagents so every Developer and Researcher run leaves an auditable trace alongside `SOLUTION.md` / `RESEARCH.md`. Each line is `{role, ...payload, ts}` — `assistant` for each model turn, `tool` for each tool result, UTC ISO timestamp on every record.

- `agents/developer.py`: `chat_log` path on `__init__`; `_log()` method; per-turn + per-tool-result writes inside the run loop. File: `task/<slug>/<run_id>/developer_v{N}/developer_chat.jsonl`.
- `agents/researcher.py`: same pattern. File: `task/<slug>/<run_id>/research_{N}/researcher_chat.jsonl`.
- No threading lock (subagents iterate sequentially, unlike MainAgent's parallel dispatch).

Stacks on top of #288 (issue #287). Together they restore the post-hoc audit surface that disappeared when the subagents went mostly silent.

## Test plan
- [x] `pytest tests/test_developer.py tests/test_researcher.py tests/test_main_agent.py` — 25 passed
- [ ] Smoke-run a short MainAgent task that triggers ≥1 Developer call and ≥1 Researcher call; confirm `developer_chat.jsonl` and `researcher_chat.jsonl` exist and contain alternating `assistant` / `tool` records that parse as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)