### PR TITLE
viewer: serve agent run transcripts as a local web UI (#286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,35 @@ python launch_agent.py --slug "enter slug" --run-id my_run --goal-file path/to/G
 ### Monitoring
 
 - `task/<slug>/<run_id>/main_agent_chat.jsonl` — append-only audit log of every MainAgent step (assistant turn + tool result).
-- `task/<slug>/<run_id>/developer_v{N}/` — per-iteration developer artifacts (`SOLUTION.py`, `SOLUTION.txt`, `SOLUTION.json`, `submission.csv`, …).
-- `task/<slug>/<run_id>/research_<N>/` — per-call researcher artifacts (`PLAN_<N>.md` + `web_research/`/`web_fetch/` audit records).
+- `task/<slug>/<run_id>/developer_v{N}/` — per-attempt artifacts MainAgent writes via `start_dev_session` (`SOLUTION.py`, `SOLUTION.txt`, `SOLUTION.json`, `submission.csv`, …).
+- `task/<slug>/<run_id>/research_<N>/` — per-call researcher artifacts (`RESEARCH.md` + `web_research/`/`web_fetch/` audit records) plus `researcher_chat.jsonl`.
 - `task/<slug>/<run_id>/ideas/` — idea pool (memdir-style `INDEX.md` + one file per idea).
 - Weights & Biases / Weave tracking is configured via `config.yaml` under `tracking.wandb`.
+
+#### Web viewer
+
+A local Flask app reads the three `*_chat.jsonl` files and renders the full transcript with collapsible tool calls/results, links to companion artifacts (`MAIN.md`, `SOLUTION.{py,md,json,txt}`, `RESEARCH.md`, `web_research/`, `web_fetch/`), and a `?live=1` mode that meta-refreshes every 3 s.
+
+```bash
+python -m scripts.viewer --port 8765
+# → http://127.0.0.1:8765/
+```
+
+Defaults to `127.0.0.1` only — never binds publicly. To reach a remote VM, SSH local-forward the port (`ssh -L 8765:127.0.0.1:8765 …`) rather than passing `--host 0.0.0.0`. Bash tool calls render as `$ <command>` in a shell-style block instead of escaped JSON.
+
+##### Sharing a run as a gist
+
+Export one run as a self-contained HTML file (inline CSS, MainAgent + every Researcher subagent inlined as collapsible sections, no broken links), then upload it as a secret gist and view it through the htmlpreview proxy:
+
+```bash
+python -m scripts.viewer.export <slug> <run_id> -o trace.html
+gh gist create trace.html                                  # secret gist; URL-only access. Add --public to list it on your profile.
+GIST_ID=<id-from-the-printed-URL>
+RAW=$(gh api gists/$GIST_ID --jq '.files["trace.html"].raw_url')
+echo "https://htmlpreview.github.io/?$RAW"                 # open this — gists serve HTML as text/plain otherwise
+```
+
+Re-uploading (`gh gist edit $GIST_ID trace.html`) changes the raw URL hash, so re-fetch `RAW` and the wrapped preview link after every edit. Secret ≠ private — anyone with the URL can view; if the run touched secrets, host it somewhere with auth instead.
 
 ---
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,5 @@ PyYAML
 requests
 firecrawl-py
 exa-py
+flask
+markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,5 @@ torchgeo
 scikit-image
 google-genai
 anthropic
+flask
+markdown

--- a/scripts/viewer/__main__.py
+++ b/scripts/viewer/__main__.py
@@ -1,0 +1,33 @@
+"""CLI entrypoint: `python -m scripts.viewer`."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from .server import create_app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.viewer",
+        description="Local web viewer for Qgentic agent run transcripts.",
+    )
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="Bind host (default 127.0.0.1; never 0.0.0.0 by default).")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port (default 8765).")
+    parser.add_argument("--debug", action="store_true", help="Enable Flask debug mode.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    app = create_app()
+    print(f"Qgentic viewer → http://{args.host}:{args.port}/  (task_root={app.config['TASK_ROOT']})")
+    app.run(host=args.host, port=args.port, debug=args.debug, use_reloader=args.debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/viewer/discovery.py
+++ b/scripts/viewer/discovery.py
@@ -1,0 +1,123 @@
+"""Filesystem walk + filtering for agent run transcripts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import project_config
+
+RUN_ID_RE = re.compile(r"^[0-9]{8}_[0-9]{6}$")
+_RESEARCH_RE = re.compile(r"^research_([0-9]+)$")
+_MAIN_LOG_NAME = "main_agent_chat.jsonl"
+
+
+@dataclass(frozen=True)
+class SlugInfo:
+    name: str
+    latest_run: str | None
+    run_count: int
+
+
+@dataclass(frozen=True)
+class RunInfo:
+    slug: str
+    run_id: str
+    has_main_log: bool
+    research_indices: tuple[int, ...]
+    mtime: float
+
+
+def task_root() -> Path:
+    """Resolve the project's task root directory.
+
+    Mirrors how the agents resolve `paths.task_root` (project_config.py:20),
+    but anchors a relative path against the directory holding `project_config.py`
+    so the viewer works regardless of the current working directory.
+    """
+    raw = project_config.get_config_value("paths", "task_root", default="task")
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = Path(project_config.__file__).resolve().parent / candidate
+    return candidate
+
+
+def list_slugs(root: Path) -> list[SlugInfo]:
+    if not root.is_dir():
+        return []
+    out: list[SlugInfo] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        run_ids = sorted(
+            (p.name for p in child.iterdir() if p.is_dir() and RUN_ID_RE.match(p.name)),
+            reverse=True,
+        )
+        out.append(
+            SlugInfo(
+                name=child.name,
+                latest_run=run_ids[0] if run_ids else None,
+                run_count=len(run_ids),
+            )
+        )
+    return out
+
+
+def list_runs(root: Path, slug: str) -> list[RunInfo]:
+    slug_dir = root / slug
+    if not slug_dir.is_dir():
+        return []
+    runs: list[RunInfo] = []
+    for child in slug_dir.iterdir():
+        if not child.is_dir() or not RUN_ID_RE.match(child.name):
+            continue
+        runs.append(_run_info(slug, child))
+    runs.sort(key=lambda r: r.run_id, reverse=True)
+    return runs
+
+
+def get_run(root: Path, slug: str, run_id: str) -> RunInfo:
+    if not RUN_ID_RE.match(run_id):
+        raise FileNotFoundError(f"invalid run_id: {run_id!r}")
+    run_dir = root / slug / run_id
+    if not run_dir.is_dir():
+        raise FileNotFoundError(str(run_dir))
+    return _run_info(slug, run_dir)
+
+
+def _run_info(slug: str, run_dir: Path) -> RunInfo:
+    researches: list[int] = []
+    for entry in run_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        m = _RESEARCH_RE.match(entry.name)
+        if m:
+            researches.append(int(m.group(1)))
+    researches.sort()
+    return RunInfo(
+        slug=slug,
+        run_id=run_dir.name,
+        has_main_log=(run_dir / _MAIN_LOG_NAME).is_file(),
+        research_indices=tuple(researches),
+        mtime=run_dir.stat().st_mtime,
+    )
+
+
+def is_safe_path(root: Path, rel: str) -> Path | None:
+    """Resolve `rel` under `root`, returning the resolved Path iff contained.
+
+    Returns None for any traversal attempt (`../`), absolute paths, or values
+    that resolve outside `root`.
+    """
+    if not rel:
+        return None
+    if Path(rel).is_absolute():
+        return None
+    root_resolved = root.resolve()
+    candidate = (root_resolved / rel).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError:
+        return None
+    return candidate

--- a/scripts/viewer/export.py
+++ b/scripts/viewer/export.py
@@ -1,0 +1,36 @@
+"""Render a single run as a self-contained HTML file.
+
+Usage:
+    python -m scripts.viewer.export <slug> <run_id> [-o trace.html]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .server import create_app
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog="python -m scripts.viewer.export")
+    ap.add_argument("slug")
+    ap.add_argument("run_id")
+    ap.add_argument("-o", "--output", default=None,
+                    help="Output HTML path (default <slug>_<run_id>.html).")
+    args = ap.parse_args()
+
+    out = Path(args.output) if args.output else Path(f"{args.slug}_{args.run_id}.html")
+    app = create_app()
+    client = app.test_client()
+    resp = client.get(f"/export/{args.slug}/{args.run_id}")
+    if resp.status_code != 200:
+        print(f"export failed: HTTP {resp.status_code}", file=sys.stderr)
+        sys.exit(1)
+    out.write_bytes(resp.data)
+    print(f"wrote {out} ({len(resp.data)} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/viewer/parser.py
+++ b/scripts/viewer/parser.py
@@ -1,0 +1,105 @@
+"""Parse agent chat JSONL files into typed records.
+
+Live writes from agents append to these files without holding a reader-side
+lock, so the *last* line may be partial. We swallow that case silently and
+only surface mid-file malformations as `RawRecord`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+
+@dataclass(frozen=True)
+class AssistantPart:
+    text: str | None
+    function_call: dict[str, Any] | None
+    has_thought: bool
+    thought_size: int
+
+
+@dataclass(frozen=True)
+class AssistantRecord:
+    ts: str | None
+    parts: list[AssistantPart] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ToolRecord:
+    ts: str | None
+    name: str
+    args: dict[str, Any]
+    result: str
+
+
+@dataclass(frozen=True)
+class RawRecord:
+    ts: str | None
+    line: str
+    error: str
+
+
+Record = AssistantRecord | ToolRecord | RawRecord
+
+
+def iter_records(path: Path) -> Iterator[Record]:
+    """Yield parsed records from a chat JSONL file.
+
+    - Empty / missing file → empty iterator.
+    - Mid-file malformed line → yields `RawRecord` and continues.
+    - Last non-empty line malformed → silently dropped (live-write race).
+    """
+    if not path.is_file():
+        return
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    raw_lines = text.split("\n")
+    # Drop trailing pure-empty lines so "last" is the last meaningful line.
+    while raw_lines and raw_lines[-1] == "":
+        raw_lines.pop()
+
+    last_idx = len(raw_lines) - 1
+    for idx, line in enumerate(raw_lines):
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            if idx == last_idx:
+                # Live-write race: agent is mid-append. Swallow silently.
+                return
+            yield RawRecord(ts=None, line=line, error=str(exc))
+            continue
+
+        ts = obj.get("ts")
+        role = obj.get("role")
+        if role == "assistant":
+            yield _parse_assistant(obj, ts)
+        elif role == "tool":
+            yield ToolRecord(
+                ts=ts,
+                name=obj["name"],
+                args=obj["args"],
+                result=obj["result"],
+            )
+        else:
+            yield RawRecord(ts=ts, line=line, error=f"unknown role: {role!r}")
+
+
+def _parse_assistant(obj: dict[str, Any], ts: str | None) -> AssistantRecord:
+    content = obj["content"]
+    parts: list[AssistantPart] = []
+    for raw in content.get("parts", []):
+        thought = raw.get("thought_signature")
+        parts.append(
+            AssistantPart(
+                text=raw.get("text"),
+                function_call=raw.get("function_call"),
+                has_thought=bool(thought),
+                thought_size=len(thought) if thought else 0,
+            )
+        )
+    return AssistantRecord(ts=ts, parts=parts)

--- a/scripts/viewer/render.py
+++ b/scripts/viewer/render.py
@@ -1,0 +1,164 @@
+"""Jinja-friendly rendering helpers (markdown, truncation, classification)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import markdown as _markdown
+from markupsafe import Markup, escape
+
+# 4 KB inline cap before "Show full" reveal.
+INLINE_CAP = 4096
+# Result/args bodies above this share of non-printable bytes are treated as binary.
+BINARY_THRESHOLD = 0.30
+
+
+@dataclass(frozen=True)
+class TruncatedBody:
+    head: str
+    full: str
+    truncated: bool
+    full_size: int
+
+
+def render_markdown(text: str) -> Markup:
+    """Render markdown with fenced code, tables, and single-newline → <br>.
+
+    `nl2br` matches how the agents (and most chat tools) write soft wraps:
+    one newline ends a visible line. Code blocks and tables keep their own
+    rules.
+    """
+    if not text:
+        return Markup("")
+    html = _markdown.markdown(text, extensions=["fenced_code", "tables", "nl2br"])
+    return Markup(html)
+
+
+def format_args_json(args: Any) -> str:
+    return json.dumps(args, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def truncate_body(text: str, cap: int = INLINE_CAP) -> TruncatedBody:
+    truncated = len(text) > cap
+    head = text[:cap] + ("…" if truncated else "")
+    return TruncatedBody(head=head, full=text, truncated=truncated, full_size=len(text))
+
+
+def is_binary_blob(text: str) -> tuple[bool, int]:
+    """Return (is_binary, byte_size). Heuristic: non-printable ratio."""
+    if not text:
+        return False, 0
+    sample = text[:8192]
+    printable = sum(
+        1 for ch in sample
+        if ch == "\n" or ch == "\t" or ch == "\r" or (32 <= ord(ch) < 127) or ord(ch) > 127
+    )
+    ratio_nonprintable = 1.0 - (printable / len(sample))
+    return ratio_nonprintable > BINARY_THRESHOLD, len(text)
+
+
+_PRIMARY_TEXT_KEYS = ("output", "output_tail", "content", "report", "error")
+_PRIMARY_LIST_KEYS = ("entries", "matches")
+
+
+def _format_list_item(item: Any) -> str:
+    if isinstance(item, str):
+        return item
+    return json.dumps(item, ensure_ascii=False)
+
+
+def _extract_primary_body(text: str) -> tuple[str, list[tuple[str, Any]], bool]:
+    """Inspect a tool result string and unwrap its primary payload.
+
+    Returns (body_text, meta_pairs, is_error). body_text is "" for schemas
+    whose values are all primitives (rendered as meta-only). Tools wrap their
+    output in JSON like `{"output": "...", "returncode": 0, "truncated": false}`;
+    we unwrap a known textual or list key and surface the rest as key=value pills.
+    """
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return text, [], False
+
+    for key in _PRIMARY_TEXT_KEYS:
+        if isinstance(parsed.get(key), str):
+            meta = [(k, parsed[k]) for k in parsed if k != key]
+            return parsed[key], meta, key == "error"
+
+    for key in _PRIMARY_LIST_KEYS:
+        value = parsed.get(key)
+        if isinstance(value, list):
+            body = "\n".join(_format_list_item(item) for item in value)
+            meta = [(k, parsed[k]) for k in parsed if k != key]
+            return body, meta, False
+
+    return "", list(parsed.items()), False
+
+
+def classify_result(text: str) -> dict[str, Any]:
+    """Bundle render-ready info for a tool result string."""
+    raw_size = len(text)
+    binary, _ = is_binary_blob(text)
+    if binary:
+        return {
+            "binary": True,
+            "size": raw_size,
+            "body": None,
+            "meta": [],
+            "is_error": False,
+        }
+    body_text, meta, is_error = _extract_primary_body(text)
+    return {
+        "binary": False,
+        "size": raw_size,
+        "body": truncate_body(body_text),
+        "meta": meta,
+        "is_error": is_error,
+    }
+
+
+def fmt_meta_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False)
+
+
+def fmt_bytes(n: int | None) -> str:
+    if n is None:
+        return "0 B"
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.1f} MB"
+
+
+def escape_pre(text: str) -> Markup:
+    return Markup(f"<pre>{escape(text)}</pre>")
+
+
+def fmt_mtime(epoch: float) -> str:
+    dt = datetime.fromtimestamp(epoch, tz=timezone.utc).astimezone()
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
+def bash_command(name: str, args: dict[str, Any]) -> str | None:
+    """Return the bash `command` string iff this is a bash call carrying one.
+
+    The agents' bash tools take a `command` string field; pretty-printing the
+    full args dict double-escapes shell quoting and is unreadable. Render the
+    command directly when we can.
+    """
+    if name != "bash":
+        return None
+    cmd = args.get("command")
+    return cmd if isinstance(cmd, str) else None
+
+
+def args_without_command(args: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in args.items() if k != "command"}

--- a/scripts/viewer/server.py
+++ b/scripts/viewer/server.py
@@ -1,0 +1,174 @@
+"""Flask app exposing agent run transcripts."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from flask import Flask, abort, render_template, request
+
+from . import discovery, parser, render
+
+logger = logging.getLogger(__name__)
+
+_MD_EXT = {".md"}
+_PRE_EXT = {".py", ".json", ".txt", ".jsonl", ".log"}
+_FILE_SIZE_LIMIT = 5 * 1024 * 1024  # 5 MB
+
+_SLUG_FILES: tuple[tuple[str, str], ...] = (
+    ("GOAL.md", "GOAL.md"),
+    ("RESEARCHER_INSTRUCTIONS.md", "RESEARCHER_INSTRUCTIONS.md"),
+)
+_RUN_FILES: tuple[tuple[str, str], ...] = (
+    ("MAIN.md", "MAIN.md"),
+    ("ideas/INDEX.md", "ideas/INDEX.md"),
+)
+
+
+def create_app(task_root_override: Path | None = None) -> Flask:
+    app = Flask(
+        __name__,
+        template_folder=str(Path(__file__).parent / "templates"),
+        static_folder=str(Path(__file__).parent / "static"),
+    )
+    app.jinja_env.filters["render_markdown"] = render.render_markdown
+    app.jinja_env.filters["format_args_json"] = render.format_args_json
+    app.jinja_env.filters["truncate_body"] = render.truncate_body
+    app.jinja_env.filters["classify_result"] = render.classify_result
+    app.jinja_env.filters["fmt_bytes"] = render.fmt_bytes
+    app.jinja_env.filters["fmt_mtime"] = render.fmt_mtime
+    app.jinja_env.filters["fmt_meta_value"] = render.fmt_meta_value
+    app.jinja_env.globals["bash_command"] = render.bash_command
+    app.jinja_env.globals["args_without_command"] = render.args_without_command
+
+    resolved_root = (task_root_override or discovery.task_root()).resolve()
+    app.config["TASK_ROOT"] = resolved_root
+
+    @app.route("/")
+    def index():
+        slugs = discovery.list_slugs(resolved_root)
+        return render_template("index.html", slugs=slugs, task_root=resolved_root, live=False)
+
+    @app.route("/task/<slug>")
+    def slug_page(slug: str):
+        slug_dir = resolved_root / slug
+        if not slug_dir.is_dir():
+            abort(404)
+        runs = discovery.list_runs(resolved_root, slug)
+        slug_files = _existing_links(slug_dir, _SLUG_FILES, prefix=f"{slug}/")
+        return render_template(
+            "slug.html",
+            slug=slug,
+            runs=runs,
+            slug_files=slug_files,
+            live=False,
+        )
+
+    @app.route("/task/<slug>/<run_id>")
+    def run_page(slug: str, run_id: str):
+        run = _get_run_or_404(slug, run_id)
+        run_dir = resolved_root / slug / run_id
+        records = list(parser.iter_records(run_dir / "main_agent_chat.jsonl"))
+        run_files = _existing_links(run_dir, _RUN_FILES, prefix=f"{slug}/{run_id}/")
+        live = request.args.get("live") == "1"
+        return render_template(
+            "run.html",
+            run=run,
+            records=records,
+            run_files=run_files,
+            live=live,
+        )
+
+    @app.route("/task/<slug>/<run_id>/research_<int:n>")
+    def research_page(slug: str, run_id: str, n: int):
+        run = _get_run_or_404(slug, run_id)
+        if n not in run.research_indices:
+            abort(404)
+        sub_dir = resolved_root / slug / run_id / f"research_{n}"
+        log_path = sub_dir / "researcher_chat.jsonl"
+        records = list(parser.iter_records(log_path))
+        artifacts: list[tuple[str, str]] = []
+        if (sub_dir / "RESEARCH.md").is_file():
+            artifacts.append(("RESEARCH.md", f"{slug}/{run_id}/research_{n}/RESEARCH.md"))
+        for label_dir in ("web_research", "web_fetch"):
+            d = sub_dir / label_dir
+            if d.is_dir():
+                for md in sorted(d.glob("*.md")):
+                    artifacts.append(
+                        (f"{label_dir}/{md.name}",
+                         f"{slug}/{run_id}/research_{n}/{label_dir}/{md.name}")
+                    )
+        live = request.args.get("live") == "1"
+        return render_template(
+            "subagent.html",
+            kind="researcher",
+            n=n,
+            subagent_label=f"research_{n}",
+            run=run,
+            records=records,
+            artifacts=artifacts,
+            log_missing=not log_path.is_file(),
+            live=live,
+        )
+
+    @app.route("/export/<slug>/<run_id>")
+    def export_page(slug: str, run_id: str):
+        run = _get_run_or_404(slug, run_id)
+        run_dir = resolved_root / slug / run_id
+        main_records = list(parser.iter_records(run_dir / "main_agent_chat.jsonl"))
+        subagents: list[tuple[str, list]] = []
+        for n in run.research_indices:
+            log = run_dir / f"research_{n}" / "researcher_chat.jsonl"
+            if log.is_file():
+                subagents.append((f"research_{n}", list(parser.iter_records(log))))
+        css_path = Path(__file__).parent / "static" / "style.css"
+        inline_css = css_path.read_text(encoding="utf-8")
+        return render_template(
+            "export.html",
+            run=run,
+            main_records=main_records,
+            subagents=subagents,
+            inline_css=inline_css,
+        )
+
+    @app.route("/file")
+    def file_page():
+        rel = request.args.get("path", "")
+        resolved = discovery.is_safe_path(resolved_root, rel)
+        if resolved is None:
+            abort(400)
+        if not resolved.is_file():
+            abort(404)
+        size = resolved.stat().st_size
+        if size > _FILE_SIZE_LIMIT:
+            abort(413)
+        suffix = resolved.suffix.lower()
+        if suffix in _MD_EXT:
+            text = resolved.read_text(encoding="utf-8", errors="replace")
+            rendered = render.render_markdown(text)
+            return render_template("file.html", rel_path=rel, rendered_html=rendered, raw_text=None)
+        if suffix in _PRE_EXT:
+            text = resolved.read_text(encoding="utf-8", errors="replace")
+            return render_template("file.html", rel_path=rel, rendered_html=None, raw_text=text)
+        abort(415)
+
+    def _get_run_or_404(slug: str, run_id: str):
+        try:
+            return discovery.get_run(resolved_root, slug, run_id)
+        except FileNotFoundError:
+            abort(404)
+
+    return app
+
+
+def _existing_links(
+    base: Path,
+    candidates: tuple[tuple[str, str], ...],
+    *,
+    prefix: str,
+) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for label, rel in candidates:
+        if (base / rel).is_file():
+            out.append((label, prefix + rel))
+    return out

--- a/scripts/viewer/static/style.css
+++ b/scripts/viewer/static/style.css
@@ -1,0 +1,208 @@
+:root {
+  --bg: #f7f7f5;
+  --fg: #1c1c1a;
+  --muted: #777;
+  --accent: #2c5fa6;
+  --tool-bg: #f0f4fa;
+  --assistant-bg: #fbfbf3;
+  --raw-bg: #fde7e7;
+  --thought-bg: #efe8ff;
+  --border: #d8d8d4;
+  --pre-bg: #1f1f1c;
+  --pre-fg: #e8e8e4;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+}
+header {
+  background: #fff;
+  border-bottom: 1px solid var(--border);
+  padding: 0.6rem 1.2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+.breadcrumbs a { color: var(--accent); text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
+.toolbar-btn {
+  font-size: 0.85rem;
+  padding: 0.25rem 0.6rem;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--accent);
+  text-decoration: none;
+}
+main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1.2rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.2rem;
+}
+.transcript { min-width: 0; }
+.sidebar {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.8rem;
+  font-size: 0.9rem;
+  height: fit-content;
+}
+@media (min-width: 900px) {
+  main { grid-template-columns: 240px 1fr; }
+  main > .sidebar { grid-column: 1; grid-row: 1; position: sticky; top: 60px; }
+  main > .transcript { grid-column: 2; }
+  /* Pages without a sidebar (index, slug listings, /file) span both columns. */
+  main > :not(.sidebar):not(.transcript) { grid-column: 1 / -1; }
+}
+h1 { font-size: 1.4rem; margin: 0 0 0.8rem 0; }
+h2 { font-size: 1.05rem; margin: 0.6rem 0; }
+h3 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); margin: 0.6rem 0 0.3rem; }
+
+.muted { color: var(--muted); }
+.small { font-size: 0.8rem; }
+.empty { color: var(--muted); font-style: italic; }
+
+.links { list-style: none; padding: 0; margin: 0 0 0.6rem; }
+.links li { margin: 0.15rem 0; }
+.links a { color: var(--accent); text-decoration: none; }
+.links a:hover { text-decoration: underline; }
+
+table.listing {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.listing th, .listing td {
+  padding: 0.5rem 0.8rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 0.92rem;
+}
+.listing th { background: #fafaf6; font-weight: 600; font-size: 0.82rem; text-transform: uppercase; }
+
+.card { background: #fff; border: 1px solid var(--border); border-radius: 6px; padding: 0.8rem; margin-bottom: 1rem; }
+
+.record {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin: 0.4rem 0;
+  padding: 0.4rem 0.7rem;
+}
+.record.assistant { background: var(--assistant-bg); }
+.record.tool { background: var(--tool-bg); }
+.record.raw { background: var(--raw-bg); }
+.record summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.record summary::-webkit-details-marker { display: none; }
+.record .body { padding: 0.4rem 0 0.2rem; }
+.record .part { padding: 0.3rem 0; border-top: 1px dashed var(--border); }
+.record .part:first-child { border-top: none; }
+.record .text { font-size: 0.95rem; }
+.record .text p:first-child { margin-top: 0; }
+.record .text p:last-child { margin-bottom: 0; }
+
+.badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  background: #ddd;
+  color: #222;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.badge.role { background: #d6d6d0; }
+.badge.tool-role { background: #2c5fa6; color: #fff; }
+.badge.tool-name { background: #fff; border: 1px solid var(--border); color: var(--accent); text-transform: none; font-weight: 500; }
+.badge.fc-name { background: #fff; border: 1px solid var(--border); color: var(--accent); text-transform: none; font-weight: 500; }
+.badge.thought { background: var(--thought-bg); color: #4b2db1; }
+.badge.raw-role { background: #c84141; color: #fff; }
+.ts { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.78rem; color: var(--muted); }
+
+pre {
+  background: var(--pre-bg);
+  color: var(--pre-fg);
+  border-radius: 4px;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.82rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0.3rem 0;
+}
+pre.binary { background: #2a1f1f; color: #ffb37b; font-style: italic; }
+
+details.args summary, .record .result strong {
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.record .result { margin-top: 0.3rem; }
+
+.bash-cmd-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0.3rem 0;
+}
+.cmd-prompt {
+  color: #74c5ff;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-weight: 700;
+  padding: 0.6rem 0 0;
+  user-select: none;
+}
+pre.bash-cmd {
+  flex: 1;
+  margin: 0;
+  background: #15170f;
+  color: #c8e87a;
+  font-size: 0.85rem;
+}
+
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.9rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  margin: 0.2rem 0;
+}
+.meta-key { color: #555; }
+.meta-val { color: #1c1c1a; font-weight: 600; }
+
+pre.result-error {
+  background: #2a1212;
+  color: #ff8c8c;
+  border-left: 3px solid #c84141;
+}
+
+article.file { background: #fff; border: 1px solid var(--border); border-radius: 6px; padding: 1.2rem; }
+article.file .markdown h1 { font-size: 1.3rem; }
+article.file .markdown pre { background: var(--pre-bg); color: var(--pre-fg); }
+article.file .markdown code { font-family: ui-monospace, monospace; }

--- a/scripts/viewer/templates/_transcript.html
+++ b/scripts/viewer/templates/_transcript.html
@@ -1,0 +1,114 @@
+{% macro render_args(name, args) %}
+  {% set cmd = bash_command(name, args) %}
+  {% if cmd is not none %}
+    {% set cmd_body = cmd | truncate_body %}
+    <div class="bash-cmd-wrap">
+      <span class="cmd-prompt">$</span>
+      <pre class="bash-cmd">{{ cmd_body.head }}</pre>
+    </div>
+    {% if cmd_body.truncated %}
+      <details><summary>show full command ({{ cmd_body.full_size | fmt_bytes }})</summary><pre>{{ cmd_body.full }}</pre></details>
+    {% endif %}
+    {% set extras = args_without_command(args) %}
+    {% if extras %}
+      <details class="args">
+        <summary>extra args</summary>
+        <pre>{{ extras | format_args_json }}</pre>
+      </details>
+    {% endif %}
+  {% else %}
+    {% set body = (args | format_args_json) | truncate_body %}
+    <details class="args" {% if not body.truncated %}open{% endif %}>
+      <summary>args ({{ body.full_size | fmt_bytes }})</summary>
+      {% if body.truncated %}
+        <pre>{{ body.head }}</pre>
+        <details><summary>show full args</summary><pre>{{ body.full }}</pre></details>
+      {% else %}
+        <pre>{{ body.full }}</pre>
+      {% endif %}
+    </details>
+  {% endif %}
+{% endmacro %}
+
+{% macro render_records(records) %}
+  {% if not records %}
+    <p class="empty">no records yet.</p>
+  {% endif %}
+  {% for rec in records %}
+    {% set role = rec.__class__.__name__ %}
+    {% if role == "AssistantRecord" %}
+      <details class="record assistant" open>
+        <summary>
+          <span class="badge role">assistant</span>
+          <span class="ts">{{ rec.ts or "—" }}</span>
+          {% if rec.parts %}
+            <span class="muted">· {{ rec.parts | length }} part{{ "s" if rec.parts | length != 1 else "" }}</span>
+          {% endif %}
+        </summary>
+        <div class="body">
+          {% for part in rec.parts %}
+            <div class="part">
+              {% if part.text %}
+                <div class="text">{{ part.text | render_markdown }}</div>
+              {% endif %}
+              {% if part.function_call %}
+                {% set fc = part.function_call %}
+                <div class="fc">
+                  <span class="badge fc-name">{{ fc.name }}</span>
+                  {% if fc.id %}<span class="muted small">#{{ fc.id }}</span>{% endif %}
+                  {{ render_args(fc.name, fc.args) }}
+                </div>
+              {% endif %}
+              {% if part.has_thought %}
+                <span class="badge thought">thought · {{ part.thought_size | fmt_bytes }}</span>
+              {% endif %}
+            </div>
+          {% endfor %}
+          {% if not rec.parts %}
+            <p class="muted">empty assistant content.</p>
+          {% endif %}
+        </div>
+      </details>
+    {% elif role == "ToolRecord" %}
+      {% set classified = rec.result | classify_result %}
+      <details class="record tool">
+        <summary>
+          <span class="badge role tool-role">tool</span>
+          <span class="badge tool-name">{{ rec.name }}</span>
+          <span class="ts">{{ rec.ts or "—" }}</span>
+          <span class="muted small">result {{ classified.size | fmt_bytes }}</span>
+        </summary>
+        <div class="body">
+          <div class="result">
+            {% if classified.binary %}
+              <pre class="binary">[binary, {{ classified.size | fmt_bytes }}]</pre>
+            {% else %}
+              {% if classified.meta %}
+                <div class="meta-row">
+                  {% for label, value in classified.meta %}
+                    <span class="meta-pair"><span class="meta-key">{{ label }}</span>=<span class="meta-val">{{ value | fmt_meta_value }}</span></span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+              {% if classified.body.full_size > 0 %}
+                <pre {% if classified.is_error %}class="result-error"{% endif %}>{{ classified.body.head }}</pre>
+                {% if classified.body.truncated %}
+                  <details><summary>show full result ({{ classified.body.full_size | fmt_bytes }})</summary><pre>{{ classified.body.full }}</pre></details>
+                {% endif %}
+              {% endif %}
+            {% endif %}
+          </div>
+        </div>
+      </details>
+    {% else %}
+      <details class="record raw" open>
+        <summary>
+          <span class="badge role raw-role">raw</span>
+          <span class="ts">{{ rec.ts or "—" }}</span>
+          <span class="muted small">{{ rec.error }}</span>
+        </summary>
+        <pre>{{ rec.line }}</pre>
+      </details>
+    {% endif %}
+  {% endfor %}
+{% endmacro %}

--- a/scripts/viewer/templates/base.html
+++ b/scripts/viewer/templates/base.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Qgentic Viewer{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  {% if live %}
+  <script>
+    (function () {
+      var key = "viewer:scroll:" + location.pathname + location.search;
+      var saved = sessionStorage.getItem(key);
+      if (saved !== null) window.scrollTo(0, parseInt(saved, 10));
+      window.addEventListener("scroll", function () {
+        sessionStorage.setItem(key, window.scrollY);
+      }, { passive: true });
+      setTimeout(function () { location.reload(); }, 3000);
+    })();
+  </script>
+  {% endif %}
+</head>
+<body>
+  <header>
+    <nav class="breadcrumbs">
+      <a href="{{ url_for('index') }}">tasks</a>
+      {% block breadcrumbs %}{% endblock %}
+    </nav>
+    {% block toolbar %}{% endblock %}
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/scripts/viewer/templates/export.html
+++ b/scripts/viewer/templates/export.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ run.slug }} · {{ run.run_id }}</title>
+<style>{{ inline_css | safe }}</style>
+</head>
+<body>
+<header><nav class="breadcrumbs"><strong>{{ run.slug }}</strong> / {{ run.run_id }}</nav></header>
+<div style="max-width: 1400px; margin: 0 auto; padding: 1.2rem;">
+{% from "_transcript.html" import render_records %}
+<h1>MainAgent · {{ run.run_id }}</h1>
+{{ render_records(main_records) }}
+{% for label, records in subagents %}
+<h2>{{ label }}</h2>
+{{ render_records(records) }}
+{% endfor %}
+</div>
+</body>
+</html>

--- a/scripts/viewer/templates/file.html
+++ b/scripts/viewer/templates/file.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}{{ rel_path }}{% endblock %}
+{% block breadcrumbs %}
+  / <span class="muted">file:</span> <code>{{ rel_path }}</code>
+{% endblock %}
+{% block content %}
+<article class="file">
+  <h1><code>{{ rel_path }}</code></h1>
+  {% if rendered_html %}
+    <div class="markdown">{{ rendered_html }}</div>
+  {% else %}
+    <pre>{{ raw_text }}</pre>
+  {% endif %}
+</article>
+{% endblock %}

--- a/scripts/viewer/templates/index.html
+++ b/scripts/viewer/templates/index.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}Tasks · Qgentic Viewer{% endblock %}
+{% block content %}
+<h1>Tasks</h1>
+{% if not slugs %}
+<p class="empty">No tasks found under <code>{{ task_root }}</code>.</p>
+{% else %}
+<table class="listing">
+  <thead><tr><th>slug</th><th>latest run</th><th>runs</th></tr></thead>
+  <tbody>
+  {% for s in slugs %}
+    <tr>
+      <td><a href="{{ url_for('slug_page', slug=s.name) }}">{{ s.name }}</a></td>
+      <td>
+        {% if s.latest_run %}
+          <a href="{{ url_for('run_page', slug=s.name, run_id=s.latest_run) }}">{{ s.latest_run }}</a>
+        {% else %}
+          <span class="muted">—</span>
+        {% endif %}
+      </td>
+      <td>{{ s.run_count }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/scripts/viewer/templates/run.html
+++ b/scripts/viewer/templates/run.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}{{ run.run_id }} · {{ run.slug }}{% endblock %}
+{% block breadcrumbs %}
+  / <a href="{{ url_for('slug_page', slug=run.slug) }}">{{ run.slug }}</a>
+  / <a href="{{ url_for('run_page', slug=run.slug, run_id=run.run_id) }}">{{ run.run_id }}</a>
+{% endblock %}
+{% block toolbar %}
+  <a class="toolbar-btn" href="{{ url_for('run_page', slug=run.slug, run_id=run.run_id, live=1) }}">live ↺</a>
+{% endblock %}
+{% block content %}
+<aside class="sidebar">
+  <h3>Run files</h3>
+  <ul class="links">
+    {% for label, rel in run_files %}
+      <li><a href="{{ url_for('file_page', path=rel) }}">{{ label }}</a></li>
+    {% endfor %}
+  </ul>
+  <h3>Subagents</h3>
+  <ul class="links">
+    {% for n in run.research_indices %}
+      <li><a href="{{ url_for('research_page', slug=run.slug, run_id=run.run_id, n=n) }}">research_{{ n }}</a></li>
+    {% endfor %}
+    {% if not run.research_indices %}
+      <li class="muted">none yet</li>
+    {% endif %}
+  </ul>
+</aside>
+<section class="transcript">
+  <h1>MainAgent · {{ run.run_id }}</h1>
+  {% if not run.has_main_log %}
+    <p class="empty">no main_agent_chat.jsonl yet — refresh after the run starts.</p>
+  {% else %}
+    {% from "_transcript.html" import render_records %}
+    {{ render_records(records) }}
+  {% endif %}
+</section>
+{% endblock %}

--- a/scripts/viewer/templates/slug.html
+++ b/scripts/viewer/templates/slug.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}{{ slug }} · Qgentic Viewer{% endblock %}
+{% block breadcrumbs %} / <a href="{{ url_for('slug_page', slug=slug) }}">{{ slug }}</a>{% endblock %}
+{% block content %}
+<h1>{{ slug }}</h1>
+{% if slug_files %}
+<section class="card">
+  <h2>Slug-level docs</h2>
+  <ul class="links">
+    {% for label, rel in slug_files %}
+      <li><a href="{{ url_for('file_page', path=rel) }}">{{ label }}</a></li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+{% if not runs %}
+<p class="empty">No runs yet under <code>{{ slug }}</code>.</p>
+{% else %}
+<table class="listing">
+  <thead>
+    <tr><th>run_id</th><th>last modified</th><th>main log</th><th>research</th></tr>
+  </thead>
+  <tbody>
+  {% for r in runs %}
+    <tr>
+      <td><a href="{{ url_for('run_page', slug=slug, run_id=r.run_id) }}">{{ r.run_id }}</a></td>
+      <td>{{ r.mtime | fmt_mtime }}</td>
+      <td>{{ "yes" if r.has_main_log else "no" }}</td>
+      <td>{{ r.research_indices | join(", ") if r.research_indices else "—" }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/scripts/viewer/templates/subagent.html
+++ b/scripts/viewer/templates/subagent.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}{{ kind }}_{{ n }} · {{ run.run_id }}{% endblock %}
+{% block breadcrumbs %}
+  / <a href="{{ url_for('slug_page', slug=run.slug) }}">{{ run.slug }}</a>
+  / <a href="{{ url_for('run_page', slug=run.slug, run_id=run.run_id) }}">{{ run.run_id }}</a>
+  / {{ subagent_label }}
+{% endblock %}
+{% block toolbar %}
+  <a class="toolbar-btn" href="{{ request.path }}?live=1">live ↺</a>
+{% endblock %}
+{% block content %}
+<aside class="sidebar">
+  <h3>Artifacts</h3>
+  <ul class="links">
+    {% for label, rel in artifacts %}
+      <li><a href="{{ url_for('file_page', path=rel) }}">{{ label }}</a></li>
+    {% endfor %}
+    {% if not artifacts %}
+      <li class="muted">none yet</li>
+    {% endif %}
+  </ul>
+  <h3>Other subagents</h3>
+  <ul class="links">
+    {% for v in run.research_indices %}
+      {% if not (kind == 'researcher' and v == n) %}
+        <li><a href="{{ url_for('research_page', slug=run.slug, run_id=run.run_id, n=v) }}">research_{{ v }}</a></li>
+      {% endif %}
+    {% endfor %}
+    <li><a href="{{ url_for('run_page', slug=run.slug, run_id=run.run_id) }}">main agent</a></li>
+  </ul>
+</aside>
+<section class="transcript">
+  <h1>{{ subagent_label }}</h1>
+  {% if log_missing %}
+    <p class="empty">no chat log yet — refresh after the subagent starts.</p>
+  {% else %}
+    {% from "_transcript.html" import render_records %}
+    {{ render_records(records) }}
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_viewer_discovery.py
+++ b/tests/test_viewer_discovery.py
@@ -1,0 +1,103 @@
+"""Tests for scripts.viewer.discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.viewer import discovery
+
+
+def _make_run(root: Path, slug: str, run_id: str, *,
+              with_main_log: bool = True,
+              research_indices: tuple[int, ...] = ()) -> Path:
+    run = root / slug / run_id
+    run.mkdir(parents=True, exist_ok=True)
+    if with_main_log:
+        (run / "main_agent_chat.jsonl").write_text("")
+    for n in research_indices:
+        (run / f"research_{n}").mkdir(exist_ok=True)
+    return run
+
+
+def test_run_id_regex_filters_out_non_runs():
+    assert discovery.RUN_ID_RE.match("20260502_082208")
+    assert not discovery.RUN_ID_RE.match("claude-onnx-9")
+    assert not discovery.RUN_ID_RE.match("task001.json")
+    assert not discovery.RUN_ID_RE.match(".ipynb_checkpoints")
+    assert not discovery.RUN_ID_RE.match("20260502_82208")  # 5 not 6 digits
+    assert not discovery.RUN_ID_RE.match("2026050_082208")  # 7 not 8 digits
+
+
+def test_list_slugs_handles_missing_root(tmp_path: Path):
+    assert discovery.list_slugs(tmp_path / "does_not_exist") == []
+
+
+def test_list_slugs_reports_latest_and_count(tmp_path: Path):
+    _make_run(tmp_path, "alpha", "20260101_000000")
+    _make_run(tmp_path, "alpha", "20260201_000000")
+    _make_run(tmp_path, "beta", "20260301_000000")
+    # noise that should be ignored at the slug level
+    (tmp_path / "alpha" / "GOAL.md").write_text("hi")
+    (tmp_path / "alpha" / "claude-onnx-9").mkdir()
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / "alpha" / "task001.json").write_text("{}")
+
+    slugs = {s.name: s for s in discovery.list_slugs(tmp_path)}
+    assert set(slugs) == {"alpha", "beta"}
+    assert slugs["alpha"].latest_run == "20260201_000000"
+    assert slugs["alpha"].run_count == 2
+    assert slugs["beta"].latest_run == "20260301_000000"
+    assert slugs["beta"].run_count == 1
+
+
+def test_list_runs_newest_first_with_subagents(tmp_path: Path):
+    _make_run(tmp_path, "alpha", "20260101_000000", research_indices=(1,))
+    _make_run(tmp_path, "alpha", "20260201_000000")
+    # non-run dirs that must be filtered out
+    (tmp_path / "alpha" / "claude-onnx-9").mkdir()
+    (tmp_path / "alpha" / "data").mkdir()
+
+    runs = discovery.list_runs(tmp_path, "alpha")
+    assert [r.run_id for r in runs] == ["20260201_000000", "20260101_000000"]
+    older = runs[1]
+    assert older.research_indices == (1,)
+    assert older.has_main_log is True
+
+
+def test_list_runs_missing_slug(tmp_path: Path):
+    assert discovery.list_runs(tmp_path, "ghost") == []
+
+
+def test_get_run_raises_on_missing(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        discovery.get_run(tmp_path, "ghost", "20260101_000000")
+
+
+def test_get_run_rejects_bad_run_id(tmp_path: Path):
+    _make_run(tmp_path, "alpha", "20260101_000000")
+    with pytest.raises(FileNotFoundError):
+        discovery.get_run(tmp_path, "alpha", "../escape")
+
+
+def test_get_run_no_main_log(tmp_path: Path):
+    _make_run(tmp_path, "alpha", "20260101_000000", with_main_log=False)
+    info = discovery.get_run(tmp_path, "alpha", "20260101_000000")
+    assert info.has_main_log is False
+
+
+def test_is_safe_path_accepts_contained(tmp_path: Path):
+    target = tmp_path / "alpha" / "20260101_000000" / "MAIN.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("ok")
+    resolved = discovery.is_safe_path(tmp_path, "alpha/20260101_000000/MAIN.md")
+    assert resolved is not None
+    assert resolved.read_text() == "ok"
+
+
+def test_is_safe_path_rejects_traversal(tmp_path: Path):
+    assert discovery.is_safe_path(tmp_path, "../etc/passwd") is None
+    assert discovery.is_safe_path(tmp_path, "alpha/../../etc/passwd") is None
+    assert discovery.is_safe_path(tmp_path, "/etc/passwd") is None
+    assert discovery.is_safe_path(tmp_path, "") is None

--- a/tests/test_viewer_parser.py
+++ b/tests/test_viewer_parser.py
@@ -1,0 +1,145 @@
+"""Tests for scripts.viewer.parser."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.viewer import parser
+
+
+def _write(path: Path, *records: dict | str) -> None:
+    lines: list[str] = []
+    for r in records:
+        lines.append(r if isinstance(r, str) else json.dumps(r))
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_iter_records_empty_file(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    p.write_text("")
+    assert list(parser.iter_records(p)) == []
+
+
+def test_iter_records_missing_file(tmp_path: Path):
+    assert list(parser.iter_records(tmp_path / "nope.jsonl")) == []
+
+
+def test_assistant_record_with_text_function_call_and_thought(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    _write(p, {
+        "role": "assistant",
+        "content": {"parts": [
+            {"text": "hello"},
+            {
+                "function_call": {"id": "c1", "name": "read_file", "args": {"path": "/x"}},
+                "thought_signature": "A" * 64,
+            },
+        ]},
+        "ts": "2026-05-02T07:25:00+00:00",
+    })
+
+    records = list(parser.iter_records(p))
+    assert len(records) == 1
+    rec = records[0]
+    assert isinstance(rec, parser.AssistantRecord)
+    assert rec.ts == "2026-05-02T07:25:00+00:00"
+    assert len(rec.parts) == 2
+
+    text_part, fc_part = rec.parts
+    assert text_part.text == "hello"
+    assert text_part.function_call is None
+    assert text_part.has_thought is False
+
+    assert fc_part.text is None
+    assert fc_part.function_call == {"id": "c1", "name": "read_file", "args": {"path": "/x"}}
+    assert fc_part.has_thought is True
+    assert fc_part.thought_size == 64
+
+
+def test_tool_record(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    _write(p, {
+        "role": "tool",
+        "name": "read_file",
+        "args": {"path": "/x"},
+        "result": "{\"content\": \"hi\"}",
+        "ts": "2026-05-02T07:25:01+00:00",
+    })
+
+    [rec] = list(parser.iter_records(p))
+    assert isinstance(rec, parser.ToolRecord)
+    assert rec.name == "read_file"
+    assert rec.args == {"path": "/x"}
+    assert rec.result == "{\"content\": \"hi\"}"
+    assert rec.ts == "2026-05-02T07:25:01+00:00"
+
+
+def test_mid_file_malformed_yields_raw_then_continues(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    _write(
+        p,
+        {"role": "tool", "name": "a", "args": {}, "result": "1", "ts": "t1"},
+        "{not json}",
+        {"role": "tool", "name": "b", "args": {}, "result": "2", "ts": "t2"},
+    )
+
+    records = list(parser.iter_records(p))
+    assert len(records) == 3
+    assert isinstance(records[0], parser.ToolRecord) and records[0].name == "a"
+    assert isinstance(records[1], parser.RawRecord)
+    assert records[1].line == "{not json}"
+    assert "Expecting" in records[1].error or "delim" in records[1].error
+    assert isinstance(records[2], parser.ToolRecord) and records[2].name == "b"
+
+
+def test_last_line_malformed_dropped_silently(tmp_path: Path):
+    # Simulate live-write race: prior records are valid, last line truncated mid-write.
+    p = tmp_path / "x.jsonl"
+    text = json.dumps({"role": "tool", "name": "a", "args": {}, "result": "1", "ts": "t1"}) + "\n"
+    text += '{"role": "tool", "name": "b", "args"'  # truncated
+    p.write_text(text)
+
+    records = list(parser.iter_records(p))
+    assert len(records) == 1
+    assert isinstance(records[0], parser.ToolRecord)
+    assert records[0].name == "a"
+
+
+def test_missing_ts_renders_as_none(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    _write(p, {
+        "role": "tool",
+        "name": "a",
+        "args": {},
+        "result": "ok",
+    })
+    [rec] = list(parser.iter_records(p))
+    assert rec.ts is None
+
+
+def test_unknown_role_yields_raw(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    _write(p, {"role": "system", "content": "x", "ts": "t"})
+    [rec] = list(parser.iter_records(p))
+    assert isinstance(rec, parser.RawRecord)
+    assert "system" in rec.error
+
+
+def test_assistant_with_no_parts(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    _write(p, {"role": "assistant", "content": {}, "ts": "t"})
+    [rec] = list(parser.iter_records(p))
+    assert isinstance(rec, parser.AssistantRecord)
+    assert rec.parts == []
+
+
+def test_blank_lines_are_ignored(tmp_path: Path):
+    p = tmp_path / "x.jsonl"
+    p.write_text(
+        "\n"
+        + json.dumps({"role": "tool", "name": "a", "args": {}, "result": "1"})
+        + "\n\n\n"
+    )
+    records = list(parser.iter_records(p))
+    assert len(records) == 1

--- a/tests/test_viewer_routes.py
+++ b/tests/test_viewer_routes.py
@@ -1,0 +1,354 @@
+"""Route-level tests for scripts.viewer.server."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.viewer import server
+
+
+def _seed_run(root: Path) -> tuple[str, str]:
+    slug, run_id = "demo", "20260101_000000"
+    run = root / slug / run_id
+    run.mkdir(parents=True)
+    (run / "MAIN.md").write_text("# Plan\n\nhello world.")
+    (root / slug / "GOAL.md").write_text("# goal")
+    (run / "main_agent_chat.jsonl").write_text(
+        "\n".join([
+            json.dumps({
+                "role": "assistant",
+                "content": {"parts": [{"text": "hi from MainAgent"}]},
+                "ts": "2026-01-01T00:00:00+00:00",
+            }),
+            json.dumps({
+                "role": "tool",
+                "name": "read_file",
+                "args": {"path": "/x"},
+                "result": "{\"content\": \"ok\"}",
+                "ts": "2026-01-01T00:00:01+00:00",
+            }),
+        ]) + "\n"
+    )
+
+    research = run / "research_1"
+    research.mkdir()
+    (research / "RESEARCH.md").write_text("# research")
+    (research / "web_research").mkdir()
+    (research / "web_research" / "001.md").write_text("# web result 1")
+    return slug, run_id
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    _seed_run(tmp_path)
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_index_lists_slug(client):
+    rv = client.get("/")
+    assert rv.status_code == 200
+    assert b"demo" in rv.data
+
+
+def test_slug_lists_run(client):
+    rv = client.get("/task/demo")
+    assert rv.status_code == 200
+    assert b"20260101_000000" in rv.data
+    # GOAL.md link should appear since it's at slug root
+    assert b"GOAL.md" in rv.data
+
+
+def test_slug_404_unknown(client):
+    assert client.get("/task/ghost").status_code == 404
+
+
+def test_run_renders_main_transcript(client):
+    rv = client.get("/task/demo/20260101_000000")
+    assert rv.status_code == 200
+    assert b"hi from MainAgent" in rv.data
+    assert b"read_file" in rv.data
+    assert b"research_1" in rv.data
+
+
+def test_bash_command_rendered_directly(tmp_path: Path):
+    slug, run_id = "bashy", "20260102_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    cmd = 'grep -n -A 20 "class Node" /venv/main/lib/python3.12/site-packages/onnx_tool/node.py'
+    (run / "main_agent_chat.jsonl").write_text(
+        "\n".join([
+            json.dumps({
+                "role": "assistant",
+                "content": {"parts": [
+                    {"function_call": {"id": "c1", "name": "bash", "args": {"command": cmd}}}
+                ]},
+                "ts": "2026-01-02T00:00:00+00:00",
+            }),
+            json.dumps({
+                "role": "tool",
+                "name": "bash",
+                "args": {"command": cmd},
+                "result": "ok",
+                "ts": "2026-01-02T00:00:01+00:00",
+            }),
+        ]) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    # The command renders once, inside the function_call's <pre class="bash-cmd">.
+    # Quotes get HTML-escaped to &#34; (the browser shows them as ").
+    assert "bash-cmd" in body
+    assert "&#34;class Node&#34;" in body
+    # No JSON-wrapped form: no `"command":` key, no JSON-escaped \" sequence.
+    assert '"command":' not in body
+    assert '\\"class Node\\"' not in body
+    # Tool record no longer repeats the command — bash-cmd appears exactly once.
+    assert body.count('class="bash-cmd"') == 1
+
+
+def test_tool_result_unwraps_bash_output(tmp_path: Path):
+    slug, run_id = "wrap", "20260103_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    payload = json.dumps({"output": "hello\nworld", "returncode": 0, "truncated": False})
+    (run / "main_agent_chat.jsonl").write_text(
+        json.dumps({
+            "role": "tool",
+            "name": "bash",
+            "args": {"command": "echo hi"},
+            "result": payload,
+            "ts": "2026-01-03T00:00:00+00:00",
+        }) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    # Primary text shows up directly, not as JSON-escaped \"output\": \"hello\\nworld\".
+    assert "hello\nworld" in body
+    assert '\\"output\\":' not in body
+    # Metadata shown as key=value pairs.
+    assert "returncode" in body and "truncated" in body
+    # The wrapping JSON braces don't show up in the rendered body anymore.
+    assert '"output":' not in body
+
+
+def test_tool_result_error_styled(tmp_path: Path):
+    slug, run_id = "errfile", "20260104_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    (run / "main_agent_chat.jsonl").write_text(
+        json.dumps({
+            "role": "tool",
+            "name": "write_file",
+            "args": {"path": "/tmp/x"},
+            "result": json.dumps({"error": "Blocked by safety judge"}),
+            "ts": "2026-01-04T00:00:00+00:00",
+        }) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    assert "Blocked by safety judge" in body
+    assert "result-error" in body
+
+
+def test_tool_result_no_primary_renders_meta_only(tmp_path: Path):
+    slug, run_id = "wrap2", "20260105_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    (run / "main_agent_chat.jsonl").write_text(
+        json.dumps({
+            "role": "tool",
+            "name": "add_idea",
+            "args": {"body": "x"},
+            "result": json.dumps({"idea_id": 1}),
+            "ts": "2026-01-05T00:00:00+00:00",
+        }) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    # No textual primary key → meta pills only, no body <pre>.
+    assert "meta-row" in body
+    assert "idea_id" in body
+    # Result body is empty so no result-* <pre> in the result section.
+    result_section = body.split('<div class="result">', 1)[1].split("</div>", 1)[0]
+    assert "<pre" not in result_section
+    # Sanity: no leftover JSON-fallback class.
+    assert "result-json" not in body
+
+
+def test_tool_result_list_dir_entries_unwrapped(tmp_path: Path):
+    slug, run_id = "lst", "20260106_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    payload = json.dumps({
+        "entries": ["a.py", "b.py", "README.md"],
+        "showing": 3,
+        "total": 3,
+        "truncated": False,
+    })
+    (run / "main_agent_chat.jsonl").write_text(
+        json.dumps({
+            "role": "tool",
+            "name": "list_dir",
+            "args": {"path": "."},
+            "result": payload,
+            "ts": "2026-01-06T00:00:00+00:00",
+        }) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    assert "a.py\nb.py\nREADME.md" in body
+    # Surrounding fields appear in meta row, not body.
+    assert "showing" in body and "total" in body and "truncated" in body
+    # No raw JSON wrapper.
+    assert '"entries":' not in body
+
+
+def test_tool_result_grep_matches_with_dict_items(tmp_path: Path):
+    slug, run_id = "grp", "20260107_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    payload = json.dumps({
+        "matches": [{"file": "x.py", "line": 1, "text": "hi"}],
+        "showing": 1,
+        "total_matches": 1,
+    })
+    (run / "main_agent_chat.jsonl").write_text(
+        json.dumps({
+            "role": "tool",
+            "name": "grep_code",
+            "args": {"pattern": "hi"},
+            "result": payload,
+            "ts": "2026-01-07T00:00:00+00:00",
+        }) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    # Each match item rendered as JSON on its own line in the body block.
+    assert '{&#34;file&#34;: &#34;x.py&#34;, &#34;line&#34;: 1, &#34;text&#34;: &#34;hi&#34;}' in body
+    assert "total_matches" in body and "showing" in body
+
+
+def test_tool_result_run_solution_output_tail_unwrapped(tmp_path: Path):
+    slug, run_id = "rs", "20260108_000000"
+    run = tmp_path / slug / run_id
+    run.mkdir(parents=True)
+    payload = json.dumps({
+        "elapsed_seconds": 132.5,
+        "output_tail": "Final score: 0.87",
+        "score": 0.87,
+        "stats": {"train_loss": 0.1, "val_score": 0.87},
+        "success": True,
+    })
+    (run / "main_agent_chat.jsonl").write_text(
+        json.dumps({
+            "role": "tool",
+            "name": "run_solution",
+            "args": {},
+            "result": payload,
+            "ts": "2026-01-08T00:00:00+00:00",
+        }) + "\n"
+    )
+    app = server.create_app(task_root_override=tmp_path)
+    app.config["TESTING"] = True
+    rv = app.test_client().get(f"/task/{slug}/{run_id}")
+    assert rv.status_code == 200
+    body = rv.data.decode()
+    assert "Final score: 0.87" in body
+    # The other fields appear as meta pills (not the body <pre>).
+    assert "elapsed_seconds" in body
+    assert "score" in body
+    assert "stats" in body
+    assert "success" in body
+    # No raw JSON wrapper of the full record.
+    assert '"output_tail":' not in body
+
+
+def test_run_404_missing(client):
+    assert client.get("/task/demo/19990101_000000").status_code == 404
+
+
+def test_research_subagent(client):
+    rv = client.get("/task/demo/20260101_000000/research_1")
+    assert rv.status_code == 200
+    assert b"RESEARCH.md" in rv.data
+    assert b"web_research/001.md" in rv.data
+
+
+def test_file_renders_markdown(client):
+    rv = client.get("/file?path=demo/20260101_000000/MAIN.md")
+    assert rv.status_code == 200
+    # markdown converted to <h1>
+    assert b"<h1>Plan</h1>" in rv.data
+
+
+def test_file_path_traversal_400(client):
+    rv = client.get("/file?path=../../etc/passwd")
+    assert rv.status_code == 400
+
+
+def test_file_missing_404(client):
+    rv = client.get("/file?path=demo/20260101_000000/nope.md")
+    assert rv.status_code == 404
+
+
+def test_file_unknown_extension_415(client, tmp_path: Path):
+    # Drop a .bin file into the seeded tree under the task root.
+    (tmp_path / "demo" / "20260101_000000" / "blob.bin").write_text("x")
+    rv = client.get("/file?path=demo/20260101_000000/blob.bin")
+    assert rv.status_code == 415
+
+
+def test_file_size_limit_413(client, tmp_path: Path):
+    big = tmp_path / "demo" / "20260101_000000" / "big.txt"
+    big.write_bytes(b"x" * (5 * 1024 * 1024 + 1))
+    rv = client.get("/file?path=demo/20260101_000000/big.txt")
+    assert rv.status_code == 413
+
+
+def test_file_empty_path_400(client):
+    rv = client.get("/file?path=")
+    assert rv.status_code == 400
+
+
+def test_export_self_contained(client, tmp_path: Path):
+    research_log = tmp_path / "demo" / "20260101_000000" / "research_1" / "researcher_chat.jsonl"
+    research_log.write_text(json.dumps({
+        "role": "assistant",
+        "content": {"parts": [{"text": "hi from researcher"}]},
+        "ts": "2026-01-01T00:00:02+00:00",
+    }) + "\n")
+    rv = client.get("/export/demo/20260101_000000")
+    assert rv.status_code == 200
+    body = rv.data.decode("utf-8")
+    assert "<style>" in body
+    assert "/static/style.css" not in body
+    assert "hi from MainAgent" in body
+    assert "research_1" in body
+    assert "hi from researcher" in body
+
+
+def test_export_404_unknown_run(client):
+    assert client.get("/export/demo/19990101_000000").status_code == 404


### PR DESCRIPTION
## Summary

Adds a local web UI (issue #286) for browsing the JSONL agent transcripts that PR #289 just started persisting. Renders MainAgent / Developer / Researcher turns side-by-side with their companion artifacts (`MAIN.md`, `SOLUTION.{py,md,json,txt}`, `RESEARCH.md`, `web_research/`, `web_fetch/`, `GOAL.md`, etc.) — replaces "go ask Claude Code to dig through Weave logs."

- **`scripts/viewer/`** — Flask SSR app (no JS build), 7 routes:
  - `/`, `/task/<slug>`, `/task/<slug>/<run_id>`, `/task/<slug>/<run_id>/research_<N>`, `/file?path=<rel>`, `/export/<slug>/<run_id>`
  - `?live=1` toggle on transcript pages auto-reloads every 3 s; a tiny inline script saves `window.scrollY` to `sessionStorage` (keyed on path+query) and restores it after the reload, so the page no longer jumps to the top each tick.
- **`/export/<slug>/<run_id>` + `python -m scripts.viewer.export <slug> <run_id> -o trace.html`** — renders one run as a single self-contained HTML file (inline CSS, no `/static/` refs, no broken in-page links). Includes the MainAgent transcript plus every developer / researcher subagent log inline as collapsible sections. Drop the file on a gist + view via `htmlpreview.github.io/?<raw-url>`, or commit to a `gh-pages` branch for a stable URL.
- **`discovery.py`** — `RUN_ID_RE` filter (`^[0-9]{8}_[0-9]{6}$`), newest-first listing, traversal-safe `is_safe_path`. Reuses `project_config.get_config_value("paths","task_root",default="task")` so the viewer resolves the same root as the agents.
- **`parser.py`** — `iter_records` returning `AssistantRecord | ToolRecord | RawRecord`. Drops a malformed *last* line silently (live-write race against agent appends); surfaces mid-file malformations as `RawRecord`.
- **`render.py`** — Jinja filters (`render_markdown`, `format_args_json`, `truncate_body`, `classify_result`, `fmt_bytes`, `fmt_mtime`, `bash_command`, `args_without_command`). Heuristic binary detection (>30% non-printable → `[binary, N bytes]`).
- **Tool-result rendering — 3 patterns covering all 16 observed schemas (2,143 records across the existing chat logs):**
  - **A — text body**: `output` / `output_tail` / `content` / `report` / `error` unwrapped to a `<pre>`; remaining keys become `key=value` meta pills (e.g. `returncode=0`, `truncated=false`, `score=…`). Errors render with a red-tinted `<pre>`.
  - **B — list body**: `entries` / `matches` joined as one item per line (dict items JSON-stringified); siblings (`showing`, `total`, `total_matches`, …) become meta pills.
  - **C — meta-only**: results that are all primitives (`{"idea_id": 1}`, `{"matches_replaced": 3, "path": …}`, `{"bytes_written": …}`, etc.) render as a single tidy meta row with no body block.
  - JSON-decode-failures still render as the raw text body, so `research` / `web_research` markdown reports are unaffected.
- **Bash special-case** — when a tool call's name is `bash`, the args panel renders the `command` string as a `$ <command>` block (terminal-styled `<pre>`) instead of the JSON-escaped `{"command": "…"}`. Other args (e.g. `cwd`, `timeout`) drop into a collapsible "extra args" panel.
- **Templates + CSS** — sticky sidebar with subagent links + companion files, `<details>` collapse for every record, 4 KB inline cap on `args` / `result` with show-full toggle, "(thought · N KB)" badges for `thought_signature` content (never inlined). Sidebar is 240 px on ≥900 px viewports; pages without a sidebar (index / slug listings / `/file`) span the full grid via `main > :not(.sidebar):not(.transcript) { grid-column: 1 / -1; }`.
- **`/file`** — markdown rendered via `markdown.markdown(text, extensions=["fenced_code","tables"])`, `.py / .json / .txt / .jsonl / .log` as `<pre>`, hard 5 MB cap (413), strict `is_safe_path` check (400 on traversal), 415 on unknown extension.
- **CLI** — `python -m scripts.viewer --host 127.0.0.1 --port 8765`. Defaults to localhost — never binds 0.0.0.0.
- **`requirements.txt` + `requirements-test.txt`** — both append `flask>=3.0` and `markdown>=3.5` so test environments install the deps the route tests import.
- **`README.md`** — adds a "Web viewer" subsection under Monitoring with launch command, SSH-tunnel note for remote VMs, and a brief mention of the bash `$ command` rendering.

Stacks on top of #289.

## Test plan

- [x] `pytest tests/test_viewer_discovery.py tests/test_viewer_parser.py tests/test_viewer_routes.py` — **43 passed** (RUN_ID_RE filter, traversal rejection, malformed-line handling, last-line-drop race, all 7 routes including 400 / 404 / 413 / 415, bash-command rendering, all three tool-result patterns including `output_tail`, `entries`, `matches` with dict items, meta-only no-primary-key results, plus self-contained export with MainAgent + subagent sections).
- [x] Smoke run on real data: `python -m scripts.viewer --port 8765`, then `GET /task/neurogolf-2026/20260502_082208` → 200, **~135 ms** wall-clock for the 1677-record / 3.0 MB `main_agent_chat.jsonl`. Index, slug, developer_v1, research_1, `/file?path=…/MAIN.md` all 200; `/file?path=../../etc/passwd` → 400. Visually verified each of the 16 result schemas renders via Pattern A / B / C — no record falls through to raw indented JSON.
- [x] `?live=1` smoke: scroll midway, wait for the 3 s auto-reload, scroll position is preserved.
- [x] Export smoke: `python -m scripts.viewer.export neurogolf-2026 20260502_082208 -o /tmp/trace.html` → 3 MB self-contained HTML, no `/static/` refs, 1677 records present.