### PR TITLE
smart text-only watchdog: terminate after 3 consecutive text-only turns (#293)

### DIFF
--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -65,6 +65,12 @@ _STUCK_NUDGE = (
     "when satisfied."
 )
 
+# Silent watchdog: after this many consecutive text-only turns (no
+# function_call), MainAgent treats the agent as disengaged from the task and
+# terminates the run cleanly. Any turn containing at least one function_call
+# resets the counter to 0.
+_TEXT_ONLY_TERMINATE_THRESHOLD = 3
+
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +110,9 @@ class MainAgent:
         self._recent_call_sigs: collections.deque[tuple[tuple[str, str], ...]] = (
             collections.deque(maxlen=_STUCK_REPEAT_THRESHOLD)
         )
+        # Silent text-only watchdog (see `_TEXT_ONLY_TERMINATE_THRESHOLD`).
+        self._consecutive_text_only = 0
+        self._done = False
         # Ensure INDEX.md exists so `load_index` has something to read.
         if not (self.ideas_dir / "INDEX.md").exists():
             (self.ideas_dir / "INDEX.md").write_text("# Idea pool\n\n")
@@ -116,7 +125,7 @@ class MainAgent:
     @weave.op()
     def run(self) -> None:
         tools = get_main_agent_tools()
-        while True:
+        while not self._done:
             self._step(tools)
 
     def _step(self, tools) -> None:
@@ -150,18 +159,22 @@ class MainAgent:
         self._log({"role": "assistant", "content": response.candidates[0].content.model_dump(mode="json", exclude_none=True)})
 
         if not has_function_calls:
-            logger.warning(
-                "MainAgent emitted text-only response; nudging back to tool use"
-            )
-            self.input_list.append(
-                append_message(
-                    "user",
-                    "Your previous turn had no function_call — every step must "
-                    "be a tool call. Pick a tool from the declared palette and "
-                    "call it now.",
+            # Text-only turns are legitimate in isolation (transient drift, a
+            # single "done / waiting" message). But sustained text-only signals
+            # the agent has disengaged — terminate the run cleanly once the
+            # watchdog threshold trips.
+            self._consecutive_text_only += 1
+            if self._consecutive_text_only >= _TEXT_ONLY_TERMINATE_THRESHOLD:
+                logger.info(
+                    "MainAgent: %d consecutive text-only turns — agent appears "
+                    "done; terminating run",
+                    self._consecutive_text_only,
                 )
-            )
+                self._done = True
+            # Nothing to dispatch on a text-only turn either way; `run()`'s
+            # `while not self._done` checks the flag on the next iteration.
             return
+        self._consecutive_text_only = 0
 
         call_parts = [
             p for p in parts if hasattr(p, "function_call") and p.function_call

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -363,19 +363,84 @@ def test_filesystem_tool_calls_route_to_filesystem_helpers(
     assert json.loads(tool_records[0]["result"])["entries"] == ["fake/"]
 
 
-def test_text_only_response_is_logged_and_ignored(patched_main_agent, monkeypatch, caplog):
+def test_single_text_only_passes_through_silently(patched_main_agent, monkeypatch):
+    """A single text-only turn is legitimate; counter increments, no termination."""
     agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
     monkeypatch.setattr(
         main_agent, "call_llm", lambda **kwargs: (_fake_text("hello"), 0)
     )
 
-    with caplog.at_level("WARNING"):
-        agent._step([])
+    agent._step([])
 
-    assert any("text-only" in rec.message for rec in caplog.records)
+    assert agent._consecutive_text_only == 1
+    assert agent._done is False
+    # Only the assistant turn was appended; no user-nudge follow-up.
+    assert agent.input_list[-1]["role"] == "model"
     records = [json.loads(line) for line in agent.chat_log.read_text().splitlines()]
     assert len(records) == 1
     assert records[0]["role"] == "assistant"
+
+
+def test_two_consecutive_text_only_does_not_terminate(patched_main_agent, monkeypatch):
+    """Two text-only turns increment the counter but stay below the watchdog."""
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (_fake_text("hello"), 0)
+    )
+
+    agent._step([])
+    agent._step([])
+
+    assert agent._consecutive_text_only == 2
+    assert agent._done is False
+
+
+def test_three_consecutive_text_only_sets_done_flag(patched_main_agent, monkeypatch):
+    """At the watchdog threshold MainAgent terminates the run cleanly."""
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (_fake_text("hello"), 0)
+    )
+
+    threshold = main_agent._TEXT_ONLY_TERMINATE_THRESHOLD
+    for _ in range(threshold):
+        agent._step([])
+
+    assert agent._consecutive_text_only == threshold
+    assert agent._done is True
+
+
+def test_function_call_resets_text_only_counter(patched_main_agent, monkeypatch):
+    """A turn containing a function_call resets the consecutive-text-only counter."""
+    agent = MainAgent(slug="test", run_id="r1", goal_text="do the thing")
+
+    monkeypatch.setattr(
+        main_agent,
+        "execute_filesystem_tool",
+        lambda name, args, *, writable_root: json.dumps(
+            {"output": "ok", "returncode": 0}
+        ),
+    )
+
+    responses = iter(
+        [
+            _fake_text("hello"),
+            _fake_text("still here"),
+            _fake_fc("read_file", path="/tmp/x.txt"),
+            _fake_text("hmm"),
+        ]
+    )
+    monkeypatch.setattr(
+        main_agent, "call_llm", lambda **kwargs: (next(responses), 0)
+    )
+
+    for _ in range(4):
+        agent._step([])
+
+    # text-only, text-only → counter=2; function_call → reset to 0;
+    # text-only → counter=1.
+    assert agent._consecutive_text_only == 1
+    assert agent._done is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #293. Replaces MainAgent's old "always nudge on text-only" handler with a silent watchdog: after 3 consecutive text-only turns (no `function_call`), `MainAgent.run()` terminates cleanly. Any turn containing at least one `function_call` resets the counter.

**Why:** A long run showed the old nudge had two distinct failure modes:
1. **False-positive on legitimate idle.** Once the agent had finished its task, it emitted text-only "done / waiting" turns. The old nudge fired ~13 times in a row with the misleading message *"every step must be a tool call"* — the agent wasn't malfunctioning, it had nothing to do.
2. **Silent JSONL divergence.** The old nudge appended a synthetic user message to `self.input_list` but never called `self._log`, so the JSONL transcript showed zero `user` records across 781 records of a real run — even though Gemini had seen many. Broke the viewer (#286 / #290) and made tracebacks harder to debug.

**Approach:** Treat sustained text-only as the disengagement signal it actually is. One text-only is fine (transient drift, single "let me investigate ..."). Two is fine. Three in a row → the agent has stopped engaging; exit the run loop instead of spinning on `sleep 1` calls forever.

The watchdog is **silent** — the prompt's `# Termination` block stays "no termination in software" so the agent doesn't get an easy "done" lever. The 3-text-only path only fires when the agent has stopped trying.

## Changes

**`agents/main_agent.py`**
- New constant `_TEXT_ONLY_TERMINATE_THRESHOLD = 3`.
- `__init__`: add `self._consecutive_text_only = 0` and `self._done = False`.
- `run()`: `while True` → `while not self._done`.
- `_step()`: replaces the old warning + invisible-nudge block with: increment counter on text-only, set `_done` when threshold trips, reset counter on any function_call turn.
- Old `_NUDGE_TEXT` constant + warning log removed.

**`tests/test_main_agent.py`**
- 4 new tests cover the ladder: single-turn pass-through, two-turn no-trigger, three-turn termination, and counter reset on function_call.
- `test_text_only_response_is_logged_and_ignored` removed (replaced).

## Test plan

- [x] `pytest tests/test_main_agent.py -v` → 14/14 pass (10 prior + 4 new).
- [x] `pytest tests/ --ignore=tests/test_helpers.py` → 110+ pass; only the pre-existing untracked test_helpers failures remain.
- [ ] Smoke run: start a MainAgent run, force three text-only responses (e.g. via prompt manipulation), verify `run()` returns cleanly and no further `_step` calls happen.