### PR TITLE
main_agent: kickoff message must demand prose before tool call

### DIFF
--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -44,8 +44,9 @@ from utils.output import truncate_for_llm
 
 _INITIAL_USER_TURN = (
     "Take your first step. The session goal, the current idea pool (INDEX.md), "
-    "and your tool palette are all in the system prompt. Pick a tool and call "
-    "it — every step should be a tool call, never a plain text response."
+    "and your tool palette are all in the system prompt. Begin with a 1-3 "
+    "sentence prose block stating your read of the goal and your opening move, "
+    "then issue the tool call(s) — every turn must lead with prose, then act."
 )
 
 # Number of consecutive turns with byte-identical tool-call signatures before


### PR DESCRIPTION
## Summary

Fix kickoff user message that was anchoring MainAgent into silent execute-mode from turn 0.

## Bug

The system prompt mandates "every turn must begin with a 1-3 sentence prose block before tool calls" (`prompts/main_agent.py:145`). The kickoff `_INITIAL_USER_TURN` told the agent the opposite: "every step should be a tool call, never a plain text response." Last instruction wins — the model resolved the conflict by dropping prose from turn 0, anchoring silent function-calling for the rest of the run.

Empirically observed: a recent run hit 0/32 prose adherence on main-agent turns despite the prose mandate being in the prompt.

## Fix

Rewrite `_INITIAL_USER_TURN` so it demands the same shape the system prompt does: prose first, then tool call(s).

## Test plan
- [x] `pytest tests/test_main_agent.py` — 14 passed
- [ ] Manual: kickoff prose adherence on next live run