### PR TITLE
main_agent: log _STUCK_NUDGE to JSONL chat transcript

### DIFF
--- a/agents/main_agent.py
+++ b/agents/main_agent.py
@@ -240,7 +240,9 @@ class MainAgent:
                 _STUCK_REPEAT_THRESHOLD,
                 [n for n, _ in turn_sig],
             )
-            self.input_list.append(append_message("user", _STUCK_NUDGE))
+            nudge_msg = append_message("user", _STUCK_NUDGE)
+            self.input_list.append(nudge_msg)
+            self._log({"role": "user", "content": nudge_msg})
             self._recent_call_sigs.clear()
 
     def _dispatch(self, name: str, args: dict) -> str:

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -295,6 +295,16 @@ def test_stuck_nudge_fires_after_repeated_identical_calls(
     assert last["role"] == "user"
     assert nudge_text in last["parts"][0]["text"]
 
+    # JSONL transcript fidelity: the nudge the LLM sees must also land in
+    # the persisted chat log. Regression for the silent-divergence bug where
+    # the nudge was appended to input_list but never logged.
+    records = [json.loads(line) for line in agent.chat_log.read_text().splitlines()]
+    user_records = [r for r in records if r.get("role") == "user"]
+    assert any(
+        nudge_text in (r.get("content", {}).get("parts", [{}])[0].get("text", ""))
+        for r in user_records
+    ), "stuck nudge must be written to JSONL chat log, not just input_list"
+
     # History reset, so the next identical turn does NOT immediately re-nudge.
     agent._step([])
     assert agent.input_list[-1]["role"] == "function"


### PR DESCRIPTION
## Summary

Fix JSONL chat-transcript fidelity bug in the stuck-nudge path.

## Bug

`_STUCK_NUDGE` was appended to `self.input_list` (which the LLM sees) but was never written via `self._log()`. The persisted `main_agent_chat.jsonl` therefore silently diverged from the conversation the LLM actually received — the nudge was invisible to anyone debugging from the transcript.

## Fix

Pull the nudge dict into a local var, append to `input_list` and log via `self._log()` in the same shape as other user-role records.

## Test plan
- [x] `pytest tests/test_main_agent.py` — 14 passed
- [x] Added JSONL fidelity assertion to `test_stuck_nudge_fires_after_repeated_identical_calls` — locks the regression