### PR TITLE
README: add architecture diagram (mermaid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Qgentic-AI is an automated ML engineering stack. LLM-driven agents take a problem description, produce a technical plan, generate code, run it locally, analyse the results, and keep refining the solution. Targeted at Kaggle-style competitions today; the stack is extensible to non-competition goals.
 
+▶ **[See an example run](https://htmlpreview.github.io/?https://gist.githubusercontent.com/bogoconic1/93fea3777d9baf5a9d67626223a83db6/raw/7dd88a442f484ce2fa8a740ae5d4636455bca54f/trace.html)** — full transcript of MainAgent + Researcher iterating on a competition, exported as a single self-contained HTML file.
+
 ## Problem Statement
 
 > "If you can solve your own problem, it's much more likely you're solving the problem for others." - The engineers of Claude Code
@@ -82,6 +84,48 @@ python create_metadata.py --competition-slug "enter slug"
 
 The original Kaggle pipeline: a MainAgent (which authors and runs SOLUTION.py directly) plus a Researcher subagent for web-grounded research, iterating on a competition with a CV metric.
 
+### Architecture
+
+```mermaid
+flowchart TB
+    USER(["User"])
+    GOAL["GOAL.md<br/>RESEARCHER_INSTRUCTIONS.md"]
+    KH[("kagglehub")]
+    GEM[("Gemini API")]
+    WEB[("Exa + Firecrawl")]
+
+    USER -->|"launch_agent.py --slug X"| LA["launch_agent.py<br/>copies inputs · downloads competition · creates run dir"]
+    GOAL --> LA
+    KH -. competition .-> LA
+
+    LA --> MA["MainAgent · Gemini loop<br/><br/>Tools<br/>start_dev_session · run_solution<br/>research · web_search_stack_trace<br/>add_idea / update_idea / remove_idea<br/>bash · read_file · write_file · edit_file<br/>list_dir · grep_code · glob_files"]
+
+    MA -. each bash call .-> JUDGE[/"LLM bash safety judge"/]
+    MA -. run_solution .-> MON[/"LLM training monitor<br/>watches stdout / stderr live"/]
+    MA -. LLM .-> GEM
+
+    MA -->|"research(instruction)"| RA["Researcher subagent · Gemini loop<br/><br/>Tools<br/>web_research · web_fetch<br/>bash · read_file · write_file · edit_file<br/>list_dir · grep_code · glob_files"]
+    RA -. LLM .-> GEM
+    RA -. search / fetch .-> WEB
+
+    MA --> RD
+    RA --> RD
+    subgraph RD["Run dir · task/&lt;slug&gt;/&lt;run_id&gt;/"]
+      direction LR
+      MAIN["MAIN.md"]
+      IDEAS["ideas/INDEX.md<br/>ideas/&lt;id&gt;.md"]
+      DEV["developer_vN/<br/>SOLUTION.py · .txt · .json · .md<br/>submission.csv"]
+      RES["research_N/<br/>RESEARCH.md · web_research/ · web_fetch/"]
+      LOG1["main_agent_chat.jsonl"]
+      LOG2["research_N/researcher_chat.jsonl"]
+    end
+
+    RD --> VS["scripts.viewer<br/>Flask · localhost:8765"]
+    RD --> VE["scripts.viewer.export<br/>self-contained trace.html"]
+```
+
+Reading the diagram: `launch_agent.py` boots a single in-process **MainAgent** (Gemini-driven) which owns SOLUTION.py authoring + execution directly — no separate developer agent. Each `bash` call is gated by a safety-judge LLM; each `run_solution` streams stdout/stderr through a training-monitor LLM that can kill the process on NaN loss / OOM / deadlock. The only subagent is **Researcher**, invoked on demand via `research(instruction)`; it does its own Gemini loop with `web_research` (Exa neural search) + `web_fetch` (Firecrawl) plus the same filesystem + bash palette MainAgent has, so it can maintain `RESEARCH.md` and probe data as it goes. Every step appends to the run dir, which is what `scripts.viewer` (live UI) and `scripts.viewer.export` (shareable single-file HTML) read.
+
 ### Create Required Files
 
 The repo ships two empty templates — `GOAL.example.md`, `RESEARCHER_INSTRUCTIONS.example.md`. Copy each one to the matching `*.md` filename and fill it in for your task; the `*.md` working copies are gitignored so per-task content never lands in the repo:
@@ -132,7 +176,9 @@ Defaults to `127.0.0.1` only — never binds publicly. To reach a remote VM, SSH
 
 ##### Sharing a run as a gist
 
-Export one run as a self-contained HTML file (inline CSS, MainAgent + every Researcher subagent inlined as collapsible sections, no broken links), then upload it as a secret gist and view it through the htmlpreview proxy:
+Export one run as a self-contained HTML file (inline CSS, MainAgent + every Researcher subagent inlined as collapsible sections, no broken links), then upload it as a secret gist and view it through the htmlpreview proxy.
+
+[**Example trace**](https://htmlpreview.github.io/?https://gist.githubusercontent.com/bogoconic1/93fea3777d9baf5a9d67626223a83db6/raw/7dd88a442f484ce2fa8a740ae5d4636455bca54f/trace.html) — what one exported run looks like.
 
 ```bash
 python -m scripts.viewer.export <slug> <run_id> -o trace.html


### PR DESCRIPTION
## Summary

Add a Mermaid architecture diagram to the README's Competition Mode section, plus an "▶ See an example run" callout at the top of the README pointing to a self-contained exported trace.

## Changes

- **Top-of-README callout**: prominent link to an example trace (htmlpreview gist) so a first-time reader can see what an actual run looks like before scrolling.
- **Mermaid flowchart** under `## Competition Mode` showing the launch flow, MainAgent's tool palette + the bash safety judge / training monitor sidecar LLMs, the Researcher subagent, the run dir layout, and the viewer/export consumers.
- **Reading-the-diagram paragraph** explaining the high-level flow in prose.
- **Example link in the gist-sharing section** as well, so readers there can see one before exporting their own.

## Accuracy

Diagram audited against the actual code:
- MainAgent tool palette matches `prompts/main_agent.py` (includes `web_search_stack_trace`).
- Researcher palette matches `prompts/research.py` (web_research/web_fetch + the full filesystem + bash palette).
- `web_research` labeled as Exa neural search, `web_fetch` as Firecrawl (per `agents/researcher.py:39-40`).
- Viewer port `8765` matches `scripts/viewer/__main__.py:18`.
- `scripts.viewer.export` is a real CLI module (`scripts/viewer/export.py`).